### PR TITLE
LPS-19137 JSONWS does not scan services of hook and web type plug-ins

### DIFF
--- a/portal-impl/src/com/liferay/portal/jsonwebservice/JSONWebServiceConfigurator.java
+++ b/portal-impl/src/com/liferay/portal/jsonwebservice/JSONWebServiceConfigurator.java
@@ -46,7 +46,7 @@ import java.util.Set;
 
 import jodd.io.findfile.ClassFinder;
 import jodd.io.findfile.FindFile;
-import jodd.io.findfile.WildcardFindFile;
+import jodd.io.findfile.RegExpFindFile;
 
 import jodd.util.ClassLoaderUtil;
 
@@ -61,8 +61,9 @@ public class JSONWebServiceConfigurator extends ClassFinder {
 
 	public JSONWebServiceConfigurator(String servletContextPath) {
 		setIncludedJars(
-			"*portal-impl.jar", "*portal-service.jar", "*_wl_cls_gen.jar",
-			"*-portlet-service*.jar");
+			"*portal-impl.jar", "*portal-service.jar",
+			"*_wl_cls_gen.jar", "*-portlet-service*.jar",
+			"*-hook-service*.jar", "*-web-service*.jar");
 
 		_servletContextPath = servletContextPath;
 	}
@@ -129,7 +130,7 @@ public class JSONWebServiceConfigurator extends ClassFinder {
 
 			classPathFiles[0] = classPathFile;
 
-			FindFile findFile = new WildcardFindFile("*-portlet-service*.jar");
+			FindFile findFile = new RegExpFindFile(".*-(portlet|hook|web)-service.*\\.jar");
 
 			findFile.searchPath(libDir);
 


### PR DESCRIPTION
Is there a reason we do not scan classes inside *-hook-service.jar and *-web-service.jar files?
