### PR TITLE
LPS-25645 UI incosistency for "Include all descendent pages" checkbox in...

### DIFF
--- a/portal-web/docroot/html/portlet/layouts_admin/publish_layout_options.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/publish_layout_options.jsp
@@ -48,7 +48,7 @@ Layout curLayout = (Layout)row.getObject();
 		</c:if>
 
 		<c:if test="<%= !curLayout.getChildren().isEmpty() %>">
-			<aui:input label="include-all-descendent-pages" name='<%= "includeChildren_" + curLayout.getPlid() %>' type="checkbox" value="1" />
+			<aui:input checked="<%= true %>" label="include-all-descendent-pages" name='<%= "includeChildren_" + curLayout.getPlid() %>' type="checkbox" value="1" />
 		</c:if>
 	</div>
 </div>


### PR DESCRIPTION
This checkbox should be checked by default since it has a value="1" attribute. Plus, it is inconistent with the description text.

Thanks!
