### PR TITLE
[TECH SUPPORT] LPS-26171

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/filters/sso/ntlm/NtlmFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/sso/ntlm/NtlmFilter.java
@@ -65,6 +65,8 @@ public class NtlmFilter extends BasePortalFilter {
 
 	@Override
 	public void init(FilterConfig filterConfig) {
+		super.init(filterConfig);
+
 		try {
 			NtlmHttpFilter ntlmFilter = new NtlmHttpFilter();
 


### PR DESCRIPTION
Hey Máté,

This should be very straight forward. Because the filter doesn't call the BaseFilter's init method, it will throw NPEs during runtime.

Thanks!
