### PR TITLE
[TECHNICAL SUPPORT] LPS-26496

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -680,6 +680,8 @@ public class PropsValues {
 
 	public static final String[] JOURNAL_ARTICLE_CUSTOM_TOKENS = PropsUtil.getArray(PropsKeys.JOURNAL_ARTICLE_CUSTOM_TOKENS);
 
+	public static final boolean JOURNAL_ARTICLE_EXPIRE_ALL_VERSIONS = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.JOURNAL_ARTICLE_EXPIRE_ALL_VERSIONS));
+
 	public static final boolean JOURNAL_ARTICLE_FORCE_AUTOGENERATE_ID = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.JOURNAL_ARTICLE_FORCE_AUTOGENERATE_ID));
 
 	public static String[] JOURNAL_ARTICLE_FORM_ADD = PropsUtil.getArray(PropsKeys.JOURNAL_ARTICLE_FORM_ADD);

--- a/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -754,11 +754,22 @@ public class JournalArticleLocalServiceImpl
 			ServiceContext serviceContext)
 		throws PortalException, SystemException {
 
-		List<JournalArticle> articles = journalArticlePersistence.findByG_A(
-			groupId, articleId, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
-			new ArticleVersionComparator(true));
+		if (PropsValues.JOURNAL_ARTICLE_EXPIRE_ALL_VERSIONS) {
 
-		for (JournalArticle article : articles) {
+			List<JournalArticle> articles = journalArticlePersistence.findByG_A(
+				groupId, articleId, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+				new ArticleVersionComparator(true));
+
+			for (JournalArticle article : articles) {
+				expireArticle(
+					userId, groupId, article.getArticleId(),
+					article.getVersion(), articleURL, serviceContext);
+			}
+		}
+		else {
+			JournalArticle article = getLatestArticle(
+				groupId, articleId, WorkflowConstants.STATUS_APPROVED);
+
 			expireArticle(
 				userId, groupId, article.getArticleId(), article.getVersion(),
 				articleURL, serviceContext);

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -8085,6 +8085,12 @@
     #
     journal.articles.search.with.index=false
 
+    #
+    # Set this to false to revert the expiration logic used in branch 5.2 so
+    # only the last approved version will be expired not all versions as it
+    # works since 6.0
+    #
+    journal.article.expire.all.versions=true
 ##
 ## Journal Content Search Portlet
 ##

--- a/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -897,6 +897,8 @@ public interface PropsKeys {
 
 	public static final String JOURNAL_ARTICLE_CUSTOM_TOKENS = "journal.article.custom.tokens";
 
+	public static final String JOURNAL_ARTICLE_EXPIRE_ALL_VERSIONS = "journal.article.expire.all.versions";
+
 	public static final String JOURNAL_ARTICLE_FORCE_AUTOGENERATE_ID = "journal.article.force.autogenerate.id";
 
 	public static final String JOURNAL_ARTICLE_FORM_ADD = "journal.article.form.add";


### PR DESCRIPTION
Hi Máté,

The concept of this is discussed by Zsigmond and Julio. We should give option to user to keep content expiration logic from 5.2, so only the latest version of the article could be expired not all of the versions.

To achieve this I introduced a new property to control which version of logic should be applied. 
