### PR TITLE
LPS-28650

### DIFF
--- a/portal-impl/src/com/liferay/portlet/sites/util/SitesUtil.java
+++ b/portal-impl/src/com/liferay/portlet/sites/util/SitesUtil.java
@@ -795,6 +795,19 @@ public class SitesUtil {
 		if (mergeFailCount >
 			PropsValues.LAYOUT_PROTOTYPE_MERGE_FAIL_THRESHOLD) {
 
+			if (_log.isWarnEnabled()) {
+				StringBundler sb = new StringBundler(6);
+
+				sb.append("Merge not performed because the fail threshold was");
+				sb.append("reached for layoutPrototypeId ");
+				sb.append(layoutPrototype.getLayoutPrototypeId());
+				sb.append(" and layoutId ");
+				sb.append(layoutPrototypeLayout.getLayoutId());
+				sb.append(". Update the count in the database to try again.");
+
+				_log.warn(sb.toString());
+			}
+
 			return;
 		}
 


### PR DESCRIPTION
Heya Mate,

Actually, we ran into this only when debugging a customer issue. The main problem is that without that warning it becomes very unobvious why the merging fails—it took us a lot of time to figure it out.

Essentially, it is just a copy'n'paste from line 913 of the same class that was put in place for the layout set.

Thanks,
Daniel
