### PR TITLE
[TECHNICAL-SUPPORT] LPS-29256 Calling portal services during Kaleo actions causes PrincipalException: PermissionChecker not initialized

### DIFF
--- a/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -2559,12 +2559,6 @@ public class JournalArticleLocalServiceImpl
 						expirationDate, true);
 				}
 
-				// Expando
-
-				ExpandoBridge expandoBridge = article.getExpandoBridge();
-
-				expandoBridge.setAttributes(serviceContext);
-
 				// Indexer
 
 				Indexer indexer = IndexerRegistryUtil.nullSafeGetIndexer(


### PR DESCRIPTION
Hi Máté,

I've consulted about this fix with Marcellus Tavares, and based on his advice I've removed the corresponding "Expando section" from JALSI.

I've also checked the annotations of JALSI, and found the LPS ticket in which the "Expando section" has been added to the updateStatus() method. It was a subtask of LPS-4829, and was committed by LPS-4831 as far as I see.

Since none of the other updateStatus() methods contain this snippet, removing it from JALSI shouldn't have any side effects.

Tested and works as expected.
Thanks for reviewing.

Regards,
Tibor
