### PR TITLE
[TECHNICAL SUPPORT] LPS-29330 Properly hide image resize fields for Creole editor's Image Info dialog

### DIFF
--- a/portal-web/docroot/html/js/editor/ckeditor.jsp
+++ b/portal-web/docroot/html/js/editor/ckeditor.jsp
@@ -65,14 +65,6 @@ String toolbarSet = (String)request.getAttribute("liferay-ui:input-editor:toolba
 <c:if test="<%= hideImageResizing %>">
 	<liferay-util:html-top outputKey="js_editor_ckeditor_hide_image_resizing">
 		<style type="text/css">
-			td.cke_dialog_ui_hbox_first {
-				display:none !important;
-			}
-
-			td.cke_dialog_footer td.cke_dialog_ui_hbox_first {
-				display:block !important;
-			}
-
 			a.cke_dialog_tab {
 				display: none !important;
 			}
@@ -163,7 +155,7 @@ String toolbarSet = (String)request.getAttribute("liferay-ui:input-editor:toolba
 	<textarea id="<%= name %>" name="<%= name %>" style="display: none;"></textarea>
 </div>
 
-<aui:script>
+<aui:script use="aui-base">
 	(function() {
 		function setData() {
 			<c:if test="<%= Validator.isNotNull(initMethod) %>">
@@ -267,6 +259,39 @@ String toolbarSet = (String)request.getAttribute("liferay-ui:input-editor:toolba
 
 			}
 		);
+
+		ckEditor.on(
+			'dialogShow',
+			function( e ) {
+
+			var definition = e.data['definition'];
+			var dialog = definition['dialog'];
+
+			if (dialog.getName() == 'image') {
+
+				var tdNodes = A.all("td .cke_dialog_ui_hbox_first");
+				var tdFooterNodes = A.all("td .cke_dialog_footer td");
+				var first = true;
+
+				tdNodes.each(function (node) {
+					if (!first) {
+						node.hide();
+					}
+					else {
+						first = false;
+					}
+				});
+
+				tdFooterNodes.each(function (node) {
+					node.show();
+				});
+
+				var imagePreviewBox = A.one("div .ImagePreviewBox");
+
+				imagePreviewBox.setStyle('width','410px');
+			}
+		});
+
 	})();
 
 </aui:script>


### PR DESCRIPTION
Hi Máté,

LPS-28428 caused a regression bug. After discussing with Nate, I created a CKEditor event handler hook where I used javascript to set the styles on the proper element to hide/unhide them. Additionally I resized the preview image box as well in the same place as we hide the unnecessary fields the preview size and position looks awkward.

If you have any concerns please let me know.

The solution was tested on IE6-7-8-9, Chrome, Safari, FF and Opera. On IE6 there are some UI differences but it could be related to it's improper CSS handling. 

Regards,
Vilmos
