### PR TITLE
[TECHNICAL-SUPPORT] LPS-29566 Prevent double HTML escaping of portlet and page titles

### DIFF
--- a/portal-web/docroot/html/themes/_unstyled/templates/init.ftl
+++ b/portal-web/docroot/html/themes/_unstyled/templates/init.ftl
@@ -293,7 +293,7 @@
 	<#assign the_title = page_group.getDescriptiveName() />
 </#if>
 
-<#if (tilesTitle == "")>
+<#if tilesTitle == "" && !pageTitle>
 	<#assign the_title = htmlUtil.escape(the_title) />
 </#if>
 

--- a/portal-web/docroot/html/themes/_unstyled/templates/init.vm
+++ b/portal-web/docroot/html/themes/_unstyled/templates/init.vm
@@ -287,7 +287,7 @@
 	#set ($the_title = $page_group.getDescriptiveName())
 #end
 
-#if ($tilesTitle == "")
+#if (($tilesTitle == "") && !$pageTitle)
 	#set ($the_title = $htmlUtil.escape($the_title))
 #end
 


### PR DESCRIPTION
Hello Máté,

Could you please review my commit?
You can find the full description of the problem and information about my modifications at http://issues.liferay.com/browse/LPS-29566?focusedCommentId=220368&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-220368

Let me know if you've any questions.

Thanks,
Tibor
