### PR TITLE
LPS-29565

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/process/ClassPathUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/process/ClassPathUtil.java
@@ -35,6 +35,7 @@ import java.net.URL;
 import java.net.URLConnection;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import javax.servlet.ServletContext;
@@ -233,6 +234,8 @@ public class ClassPathUtil {
 		}
 
 		File[] files = dir.listFiles();
+
+		Arrays.sort(files);
 
 		StringBundler sb = new StringBundler(files.length * 2);
 


### PR DESCRIPTION
Hey Máté,

This is just a fix to have a consistent behavior for Ext plugins within forked processes. Right now there's no guarantee that the Ext jars will actually overwrite the core classes because we do not put an order on the classpath entries.

Tomcat essentially does the same thing when preparing the classpath (see org.apache.naming.resources.FileDirContext).

Thanks!
Daniel
