### PR TITLE
[TECH SUPPORT] LPS-28363

### DIFF
--- a/portal-impl/src/com/liferay/portlet/layoutconfiguration/util/RuntimePageImpl.java
+++ b/portal-impl/src/com/liferay/portlet/layoutconfiguration/util/RuntimePageImpl.java
@@ -237,11 +237,15 @@ public class RuntimePageImpl implements RuntimePage {
 		LayoutTemplate layoutTemplate = getLayoutTemplate(
 			templateResource.getTemplateId());
 
-		String pluginServletContextName = GetterUtil.getString(
-			layoutTemplate.getServletContextName());
+		ServletContext pluginServletContext = null;
 
-		ServletContext pluginServletContext = ServletContextPool.get(
-			pluginServletContextName);
+		if (layoutTemplate != null) {
+			String pluginServletContextName = GetterUtil.getString(
+				layoutTemplate.getServletContextName());
+
+			pluginServletContext = ServletContextPool.get(
+				pluginServletContextName);
+		}
 
 		ClassLoader pluginClassLoader = null;
 


### PR DESCRIPTION
Hi Máté,

Riccardo already sent a pull for this before... it's about exceptions after undeploying a layout template. 

I decided to go a different way though and just added a null check. The problem is that we cannot assume that a certain layout template actually exists—it could in fact be a plugin which has already been removed.

Thanks,
Daniel
