### PR TITLE
LPS-39846 Make sure the importedDLFileEntry is initialized in the DLFile...

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/lar/DLFileEntryTypeStagedModelDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/lar/DLFileEntryTypeStagedModelDataHandler.java
@@ -179,6 +179,10 @@ public class DLFileEntryTypeStagedModelDataHandler
 					fileEntryType.getNameMap(),
 					fileEntryType.getDescriptionMap(), ddmStructureIdsArray,
 					serviceContext);
+
+				importedDLFileEntryType =
+					DLFileEntryTypeLocalServiceUtil.fetchDLFileEntryType(
+						existingDLFileEntryType.getFileEntryTypeId());
 			}
 		}
 		else {


### PR DESCRIPTION
Hi,

Here is the fix for the LPS-39846. The fix is to make sure the importedDLFileEntryType is initialized in the DLFileEntryTypeStagedModel.

Cheers,
Laci
