### PR TITLE
LPS-40704 Checking if the expandoBridgeAttributeMap is null during check...

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -538,7 +538,8 @@ public class DLFileEntryLocalServiceImpl
 		Map<String, Serializable> expandoBridgeAttributes =
 			serviceContext.getExpandoBridgeAttributes();
 
-		if (expandoBridgeAttributes.isEmpty()) {
+		if ((expandoBridgeAttributes == null) ||
+				expandoBridgeAttributes.isEmpty()) {
 			ExpandoBridge expandoBridge =
 				ExpandoBridgeFactoryUtil.getExpandoBridge(
 					serviceContext.getCompanyId(), DLFileEntry.class.getName(),


### PR DESCRIPTION
Hi,

To fix this issue I added a null-check  for the expandoBridgeAttributeMap, in the checkOutFileEntry in the DLFileEntryLocalServiceImpl. When this map was null, the isEmpty threw the NPE causing the publish to fail.

Hope this is the correct solution.

Thanks,
Laci
