### PR TITLE
LPS-43988 Update ExportImportHelperUtilTest - Validate layoutId and groupId replacement

### DIFF
--- a/portal-impl/test/integration/com/liferay/portal/lar/dependencies/layout_links_ids_replacement.txt
+++ b/portal-impl/test/integration/com/liferay/portal/lar/dependencies/layout_links_ids_replacement.txt
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+
+<root available-locales="en_US" default-locale="en_US">
+	<dynamic-element name="link_to_page1" type="link_to_layout" index-type="keyword">
+		<dynamic-content language-id="en_US"><![CDATA[[$LAYOUT_ID_PRIVATE$]@private-group@[$GROUP_ID_PRIVATE$]]]></dynamic-content>
+	</dynamic-element>
+	<dynamic-element name="link_to_page2" type="link_to_layout" index-type="keyword">
+		<dynamic-content language-id="en_US"><![CDATA[[$LAYOUT_ID_PUBLIC$]@public@[$GROUP_ID_PUBLIC$]]]></dynamic-content>
+	</dynamic-element>
+</root>


### PR DESCRIPTION
Hi Máté,

the fix for the issue has been already committed, however I would like to extend the tests a little bit.

The original testImportLinksToLayouts method doesn't validate the layoutId and groupId replacement which is a crucial part. When the test is running, during the import the layouts cannot be found on the live site so the Ids won't be replaced at all.

In the new test method I'm exporting/importing the layouts, so the groupIds will be different. I added some layouts to the live group, so the imported layouts will have different layoutIds as the original ones.

Tamás
