### PR TITLE
[TECHNICAL-SUPPORT] LPS-46359 Source formatting - Indicate that replaceExportDLReferences should be called before replaceExportLayoutReferences

### DIFF
--- a/portal-impl/src/com/liferay/portal/lar/ExportImportHelperImpl.java
+++ b/portal-impl/src/com/liferay/portal/lar/ExportImportHelperImpl.java
@@ -713,6 +713,7 @@ public class ExportImportHelperImpl implements ExportImportHelper {
 		content = replaceExportDLReferences(
 			portletDataContext, entityStagedModel, content,
 			exportReferencedContent);
+
 		content = replaceExportLayoutReferences(portletDataContext, content);
 		content = replaceExportLinksToLayouts(
 			portletDataContext, entityStagedModel, content);
@@ -1162,6 +1163,7 @@ public class ExportImportHelperImpl implements ExportImportHelper {
 
 		content = replaceImportDLReferences(
 			portletDataContext, entityStagedModel, content);
+
 		content = replaceImportLayoutReferences(portletDataContext, content);
 		content = replaceImportLinksToLayouts(portletDataContext, content);
 


### PR DESCRIPTION
Hi Máté,

one of our customer reported an issue about the links replacement during the export/import process. 

In a nutshell:
when the context path is set, if there is a link to a document in a journal article, after the export/import process is finished, the link doesn't work anymore.
See LPP-12264.

The problem is that, on 62x replaceExportLayoutReferences is called before replaceExportDLReferences.
replaceExportLayoutReferences finds the context path in the link, and replaces to a placeholder (DATA_HANDLER_PATH_CONTEXT). 
As in replaceExportDLReferences the patterns contains  the context path,  there won't be any match, and the link remains untouched.

On trunk LPS-46359 already fixed this issue unintentionally.

To verify this issue on trunk, I tested it by switching the methods order, and I was able to reproduce the problem.
