### PR TITLE
LPS-49013

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/lar/BaseStagedModelDataHandler.java
+++ b/portal-service/src/com/liferay/portal/kernel/lar/BaseStagedModelDataHandler.java
@@ -560,11 +560,7 @@ public abstract class BaseStagedModelDataHandler<T extends StagedModel>
 			try {
 				TrashedModel trashedModel = (TrashedModel)stagedModel;
 
-				TrashHandler trashHandler = trashedModel.getTrashHandler();
-
-				long trashEntryclassPK = trashedModel.getTrashEntryClassPK();
-
-				if (trashHandler.isInTrash(trashEntryclassPK)) {
+				if (trashedModel.isInTrash()) {
 					PortletDataException pde = new PortletDataException(
 						PortletDataException.STATUS_IN_TRASH);
 


### PR DESCRIPTION
Hi Maté,

I sent this pull (https://github.com/ealonso/liferay-portal/pull/242) to @ealonso. He asked to me to retest with his SF and resend to you. 

**Root cause of problem:**
- JournalArticleTrashHandler.isInTrash(long classPK) expects "resourcePrimKey" as input
- At BaseStagedModelDataHandler the getPrimaryKeyObj is used for JournalArticle ('id_' instead 'resourceprimkey') so no JournalArticle is obtained from database

**Solution:**
1. Replace getPrimaryKeyObj() with getTrashEntryClassPK(). 
This function returns correct resourcePrimKey for JournalArticle and primaryKey for rest of objects.
2. The function belongs to TrashedModel, so instead checking (trashHandler != null), I replace it with (stagedModel instanceof TrashedModel). 
All objects with trashHandler must inherit TrashedModel, so check is equivalent.
