### PR TITLE
[TECHNICAL-SUPPORT] LPS-51988 Staging - Modified Templates aren't published when the related Structures haven't been modified

### DIFF
--- a/portal-impl/src/com/liferay/portlet/journal/lar/JournalPortletDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/journal/lar/JournalPortletDataHandler.java
@@ -490,6 +490,21 @@ public class JournalPortletDataHandler extends BasePortletDataHandler {
 
 					DDMTemplate ddmTemplate = (DDMTemplate)object;
 
+					if (ddmTemplate.getClassPK() != 0) {
+						DDMStructure ddmStructure =
+							DDMStructureLocalServiceUtil.fetchDDMStructure(
+								ddmTemplate.getClassPK());
+
+						long classNameId = PortalUtil.getClassNameId(
+							JournalArticle.class);
+
+						if ((ddmStructure != null) &&
+							(ddmStructure.getClassNameId() != classNameId)) {
+
+							return;
+						}
+					}
+
 					if (export) {
 						StagedModelDataHandlerUtil.exportStagedModel(
 							portletDataContext, ddmTemplate);

--- a/portal-impl/src/com/liferay/portlet/journal/lar/JournalPortletDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/journal/lar/JournalPortletDataHandler.java
@@ -187,19 +187,18 @@ public class JournalPortletDataHandler extends BasePortletDataHandler {
 
 			ddmStructureActionableDynamicQuery.performActions();
 
+			ActionableDynamicQuery ddmTemplateActionableDynamicQuery =
+				getDDMTemplateActionableDynamicQuery(
+					portletDataContext, ddmTemplates, true);
+
+			ddmTemplateActionableDynamicQuery.performActions();
+
 			// Export templates that belong to structures
 
 			for (DDMTemplate ddmTemplate : ddmTemplates) {
 				StagedModelDataHandlerUtil.exportStagedModel(
 					portletDataContext, ddmTemplate);
 			}
-
-			// Export templates that do not belong to structures
-
-			ActionableDynamicQuery ddmTemplateActionableDynamicQuery =
-				getDDMTemplateActionableDynamicQuery(portletDataContext);
-
-			ddmTemplateActionableDynamicQuery.performActions();
 		}
 
 		if (portletDataContext.getBooleanParameter(NAMESPACE, "web-content")) {
@@ -315,7 +314,10 @@ public class JournalPortletDataHandler extends BasePortletDataHandler {
 			portletDataContext.getManifestSummary();
 
 		ActionableDynamicQuery ddmTemplateActionableDynamicQuery =
-			getDDMTemplateActionableDynamicQuery(portletDataContext);
+			getDDMTemplateActionableDynamicQuery(
+				portletDataContext, ddmTemplates, false);
+
+		ddmTemplateActionableDynamicQuery.performActions();
 
 		manifestSummary.addModelAdditionCount(
 			new StagedModelType(DDMTemplate.class, DDMStructure.class),
@@ -452,7 +454,8 @@ public class JournalPortletDataHandler extends BasePortletDataHandler {
 	}
 
 	protected ActionableDynamicQuery getDDMTemplateActionableDynamicQuery(
-		final PortletDataContext portletDataContext) {
+		final PortletDataContext portletDataContext,
+		final List<DDMTemplate> ddmTemplates, final boolean export) {
 
 		ExportActionableDynamicQuery exportActionableDynamicQuery =
 			DDMTemplateLocalServiceUtil.getExportActionableDynamicQuery(
@@ -475,6 +478,24 @@ public class JournalPortletDataHandler extends BasePortletDataHandler {
 						DDMStructure.class);
 
 					dynamicQuery.add(classNameIdProperty.eq(classNameId));
+				}
+
+			});
+		exportActionableDynamicQuery.setPerformActionMethod(
+			new ActionableDynamicQuery.PerformActionMethod() {
+
+				@Override
+				public void performAction(Object object)
+					throws PortalException {
+
+					DDMTemplate ddmTemplate = (DDMTemplate)object;
+
+					if (export) {
+						StagedModelDataHandlerUtil.exportStagedModel(
+							portletDataContext, ddmTemplate);
+					}
+
+					ddmTemplates.remove(ddmTemplate);
 				}
 
 			});

--- a/portal-impl/src/com/liferay/portlet/journal/lar/JournalPortletDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/journal/lar/JournalPortletDataHandler.java
@@ -475,11 +475,6 @@ public class JournalPortletDataHandler extends BasePortletDataHandler {
 						DDMStructure.class);
 
 					dynamicQuery.add(classNameIdProperty.eq(classNameId));
-
-					Property classPKProperty = PropertyFactoryUtil.forName(
-						"classPK");
-
-					dynamicQuery.add(classPKProperty.eq(-1L));
 				}
 
 			});


### PR DESCRIPTION
Hi Máté,

this fix handles the Journal related Templates, we will need something similar for DDL.

Unfortunately, there is still problems with counting the exported Templates.

Calling ddmTemplateActionableDynamicQuery.performCount() counts DDL releated Templates as well.

As far as I know, we cannot create a query which gives back only the Journal related templates.

It would be possible to count the DDL releated Templates in the performAction method, but it seems weird to me, as the real problem is that we cannot tell from a Template whether it's related to the Journal or not.

What do you think?

Thanks,
Tamás
