### PR TITLE
LPS-54392 Referenced content is not found during the import process

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/lar/DLFileEntryTypeStagedModelDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/lar/DLFileEntryTypeStagedModelDataHandler.java
@@ -145,7 +145,7 @@ public class DLFileEntryTypeStagedModelDataHandler
 		DLFileEntryType existingFileEntryType = null;
 
 		existingFileEntryType = fetchExistingFileEntryType(
-			uuid, groupId, fileEntryTypeKey, preloaded);
+			uuid, groupId, fileEntryTypeKey, preloaded, true);
 
 		Map<Long, Long> fileEntryTypeIds =
 			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
@@ -181,7 +181,7 @@ public class DLFileEntryTypeStagedModelDataHandler
 			referenceElement.attributeValue("preloaded"));
 
 		DLFileEntryType existingFileEntryType = fetchExistingFileEntryType(
-			uuid, groupId, fileEntryTypeKey, preloaded);
+			uuid, groupId, fileEntryTypeKey, preloaded, true);
 
 		if (existingFileEntryType == null) {
 			return false;
@@ -270,7 +270,7 @@ public class DLFileEntryTypeStagedModelDataHandler
 				fetchExistingFileEntryType(
 					fileEntryType.getUuid(),
 					portletDataContext.getScopeGroupId(),
-					fileEntryType.getFileEntryTypeKey(), preloaded);
+					fileEntryType.getFileEntryTypeKey(), preloaded, false);
 
 			if (existingDLFileEntryType == null) {
 				serviceContext.setUuid(fileEntryType.getUuid());
@@ -340,13 +340,20 @@ public class DLFileEntryTypeStagedModelDataHandler
 	}
 
 	protected DLFileEntryType fetchExistingFileEntryType(
-		String uuid, long groupId, String fileEntryTypeKey, boolean preloaded) {
+		String uuid, long groupId, String fileEntryTypeKey, boolean preloaded,
+		boolean includeGroupHierarchy) {
 
 		DLFileEntryType existingDLFileEntryType = null;
 
 		if (!preloaded) {
-			existingDLFileEntryType = fetchStagedModelByUuidAndGroupId(
-				uuid, groupId);
+			if (includeGroupHierarchy) {
+				existingDLFileEntryType = super.fetchMissingReference(
+					uuid, groupId);
+			}
+			else {
+				existingDLFileEntryType = fetchStagedModelByUuidAndGroupId(
+					uuid, groupId);
+			}
 		}
 		else {
 			existingDLFileEntryType =

--- a/portal-impl/src/com/liferay/portlet/dynamicdatamapping/lar/DDMStructureStagedModelDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatamapping/lar/DDMStructureStagedModelDataHandler.java
@@ -144,7 +144,7 @@ public class DDMStructureStagedModelDataHandler
 		DDMStructure existingStructure = null;
 
 		existingStructure = fetchExistingStructure(
-			uuid, groupId, classNameId, structureKey, preloaded);
+			uuid, groupId, classNameId, structureKey, preloaded, true);
 
 		Map<Long, Long> structureIds =
 			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
@@ -186,7 +186,7 @@ public class DDMStructureStagedModelDataHandler
 			referenceElement.attributeValue("preloaded"));
 
 		DDMStructure existingStructure = fetchExistingStructure(
-			uuid, groupId, classNameId, structureKey, preloaded);
+			uuid, groupId, classNameId, structureKey, preloaded, true);
 
 		if (existingStructure == null) {
 			return false;
@@ -261,7 +261,7 @@ public class DDMStructureStagedModelDataHandler
 			DDMStructure existingStructure = fetchExistingStructure(
 				structure.getUuid(), portletDataContext.getScopeGroupId(),
 				structure.getClassNameId(), structure.getStructureKey(),
-				preloaded);
+				preloaded, false);
 
 			if (existingStructure == null) {
 				serviceContext.setUuid(structure.getUuid());
@@ -300,12 +300,18 @@ public class DDMStructureStagedModelDataHandler
 
 	protected DDMStructure fetchExistingStructure(
 		String uuid, long groupId, long classNameId, String structureKey,
-		boolean preloaded) {
+		boolean preloaded, boolean includeGroupHierarchy) {
 
 		DDMStructure existingStructure = null;
 
 		if (!preloaded) {
-			existingStructure = fetchStagedModelByUuidAndGroupId(uuid, groupId);
+			if (includeGroupHierarchy) {
+				existingStructure = super.fetchMissingReference(uuid, groupId);
+			}
+			else {
+				existingStructure = fetchStagedModelByUuidAndGroupId(
+					uuid, groupId);
+			}
 		}
 		else {
 			existingStructure = DDMStructureLocalServiceUtil.fetchStructure(

--- a/portal-impl/src/com/liferay/portlet/dynamicdatamapping/lar/DDMTemplateStagedModelDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatamapping/lar/DDMTemplateStagedModelDataHandler.java
@@ -153,7 +153,7 @@ public class DDMTemplateStagedModelDataHandler
 		DDMTemplate existingTemplate = null;
 
 		existingTemplate = fetchExistingTemplate(
-			uuid, groupId, classNameId, templateKey, preloaded);
+			uuid, groupId, classNameId, templateKey, preloaded, true);
 
 		Map<Long, Long> templateIds =
 			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
@@ -195,7 +195,7 @@ public class DDMTemplateStagedModelDataHandler
 			referenceElement.attributeValue("preloaded"));
 
 		DDMTemplate existingTemplate = fetchExistingTemplate(
-			uuid, groupId, classNameId, templateKey, preloaded);
+			uuid, groupId, classNameId, templateKey, preloaded, true);
 
 		if (existingTemplate == null) {
 			return false;
@@ -339,7 +339,7 @@ public class DDMTemplateStagedModelDataHandler
 				DDMTemplate existingTemplate = fetchExistingTemplate(
 					template.getUuid(), portletDataContext.getScopeGroupId(),
 					template.getClassNameId(), template.getTemplateKey(),
-					preloaded);
+					preloaded, false);
 
 				if (existingTemplate == null) {
 					serviceContext.setUuid(template.getUuid());
@@ -398,12 +398,18 @@ public class DDMTemplateStagedModelDataHandler
 
 	protected DDMTemplate fetchExistingTemplate(
 		String uuid, long groupId, long classNameId, String templateKey,
-		boolean preloaded) {
+		boolean preloaded, boolean includeGroupHierarchy) {
 
 		DDMTemplate existingTemplate = null;
 
 		if (!preloaded) {
-			existingTemplate = fetchStagedModelByUuidAndGroupId(uuid, groupId);
+			if (includeGroupHierarchy) {
+				existingTemplate = super.fetchMissingReference(uuid, groupId);
+			}
+			else {
+				existingTemplate = fetchStagedModelByUuidAndGroupId(
+					uuid, groupId);
+			}
 		}
 		else {
 			existingTemplate = DDMTemplateLocalServiceUtil.fetchTemplate(

--- a/portal-impl/src/com/liferay/portlet/journal/lar/JournalArticleStagedModelDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/journal/lar/JournalArticleStagedModelDataHandler.java
@@ -210,7 +210,7 @@ public class JournalArticleStagedModelDataHandler
 
 		existingArticle = fetchExistingArticle(
 			uuid, articleResourceUuid, groupId, articleArticleId, null, 0.0,
-			preloaded);
+			preloaded, true);
 
 		Map<String, String> articleArticleIds =
 			(Map<String, String>)portletDataContext.getNewPrimaryKeysMap(
@@ -253,7 +253,7 @@ public class JournalArticleStagedModelDataHandler
 
 		JournalArticle existingArticle = fetchExistingArticle(
 			uuid, articleResourceUuid, groupId, articleArticleId, null, 0.0,
-			preloaded);
+			preloaded, true);
 
 		if (existingArticle == null) {
 			return false;
@@ -640,7 +640,7 @@ public class JournalArticleStagedModelDataHandler
 				JournalArticle existingArticle = fetchExistingArticle(
 					article.getUuid(), articleResourceUuid,
 					portletDataContext.getScopeGroupId(), articleId,
-					newArticleId, article.getVersion(), preloaded);
+					newArticleId, article.getVersion(), preloaded, false);
 
 				if (existingArticle == null) {
 					importedArticle = JournalArticleLocalServiceUtil.addArticle(
@@ -741,7 +741,7 @@ public class JournalArticleStagedModelDataHandler
 		JournalArticle existingArticle = fetchExistingArticle(
 			article.getUuid(), articleResourceUuid,
 			portletDataContext.getScopeGroupId(), article.getArticleId(),
-			article.getArticleId(), article.getVersion(), preloaded);
+			article.getArticleId(), article.getVersion(), preloaded, false);
 
 		if ((existingArticle == null) || !existingArticle.isInTrash()) {
 			return;
@@ -800,13 +800,19 @@ public class JournalArticleStagedModelDataHandler
 	protected JournalArticle fetchExistingArticle(
 		String articleUuid, String articleResourceUuid, long groupId,
 		String articleId, String newArticleId, double version,
-		boolean preloaded) {
+		boolean preloaded, boolean includeGroupHierarchy) {
 
 		JournalArticle existingArticle = null;
 
 		if (!preloaded) {
-			existingArticle = fetchStagedModelByUuidAndGroupId(
-				articleUuid, groupId);
+			if (includeGroupHierarchy) {
+				existingArticle = super.fetchMissingReference(
+					articleUuid, groupId);
+			}
+			else {
+				existingArticle = fetchStagedModelByUuidAndGroupId(
+					articleUuid, groupId);
+			}
 
 			if (existingArticle != null) {
 				return existingArticle;


### PR DESCRIPTION
Hey Máté,

we talked about this issue a few days ago, the problem is that some **StadegModelDataHandlers**override the **validateReference** method, therefore the referred contents are not find in special cases.

I think the first step should be to invoke the general **fetchMissingReference** method when we are fetching the entities by **uuid** and **groupId**.

Tamás
