### PR TITLE
[TECHNICAL-SUPPORT] LPS-54732 Asset Publisher - multiple notifications after export/import

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/com/liferay/asset/publisher/web/lar/AssetPublisherPortletDataHandler.java
+++ b/modules/apps/asset/asset-publisher-web/src/com/liferay/asset/publisher/web/lar/AssetPublisherPortletDataHandler.java
@@ -42,6 +42,7 @@ import com.liferay.portal.service.CompanyLocalServiceUtil;
 import com.liferay.portal.service.LayoutLocalServiceUtil;
 import com.liferay.portal.service.PortletLocalServiceUtil;
 import com.liferay.portal.util.PortalUtil;
+import com.liferay.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portlet.asset.model.AssetCategory;
 import com.liferay.portlet.asset.model.AssetEntry;
 import com.liferay.portlet.asset.model.AssetVocabulary;
@@ -137,6 +138,24 @@ public class AssetPublisherPortletDataHandler
 		}
 
 		return 0;
+	}
+
+	protected void restorePortletPreference(
+			PortletDataContext portletDataContext, String name,
+			PortletPreferences portletPreferences)
+		throws Exception {
+
+		Layout layout = LayoutLocalServiceUtil.getLayout(
+			portletDataContext.getPlid());
+
+		PortletPreferences originalPortletPreferences =
+			PortletPreferencesFactoryUtil.getLayoutPortletSetup(
+				layout, portletDataContext.getPortletId());
+
+		String[] values = originalPortletPreferences.getValues(
+			name, new String[] {StringPool.BLANK});
+
+		portletPreferences.setValues(name, values);
 	}
 
 	protected void updateExportClassNameIds(
@@ -448,6 +467,9 @@ public class AssetPublisherPortletDataHandler
 					portletDataContext.getPlid());
 			}
 		}
+
+		restorePortletPreference(
+			portletDataContext, "notifiedAssetEntryIds", portletPreferences);
 
 		return portletPreferences;
 	}


### PR DESCRIPTION
Hey Máté,

the AP stores a list about the asset entries which were already handled by the notification system.

The problem is that during the import process this preference is overridden, so we loose this information.

I checked whether there are examples for restoring the original preference and I could only find one similar functionality.

In **PortletImporter**, if **preserveScopeLayoutId** is false, we restore the original values for **lfrScopeType** and **lfrScopeLayoutUuid**.

I followed this pattern for the AP as well.

Thanks,
Tamás