### PR TITLE
[TECH SUPPORT] LPS-53885 Don't remove undeployed portlets automatically from the page

### DIFF
--- a/portal-impl/src/com/liferay/portal/lar/ExportImportHelperImpl.java
+++ b/portal-impl/src/com/liferay/portal/lar/ExportImportHelperImpl.java
@@ -237,7 +237,7 @@ public class ExportImportHelperImpl implements ExportImportHelper {
 		Portlet portlet = PortletLocalServiceUtil.getPortletById(
 			companyId, portletId);
 
-		if (portlet == null) {
+		if ((portlet == null) || portlet.isUndeployedPortlet()) {
 			return null;
 		}
 
@@ -1925,7 +1925,7 @@ public class ExportImportHelperImpl implements ExportImportHelper {
 		Portlet portlet = PortletLocalServiceUtil.getPortletById(
 			companyId, portletId);
 
-		if (portlet == null) {
+		if ((portlet == null) || portlet.isUndeployedPortlet()) {
 			return false;
 		}
 

--- a/portal-impl/src/com/liferay/portal/lar/PortletExporter.java
+++ b/portal-impl/src/com/liferay/portal/lar/PortletExporter.java
@@ -609,12 +609,13 @@ public class PortletExporter {
 			portletDataContext.getCompanyId(),
 			portletDataContext.getPortletId());
 
-		if (portlet == null) {
+		if ((portlet == null) || portlet.isUndeployedPortlet()) {
 			if (_log.isDebugEnabled()) {
 				_log.debug(
 					"Do not export portlet " +
 						portletDataContext.getPortletId() +
-							" because the portlet does not exist");
+							" because the portlet does not exist or it has " +
+								"been undeployed");
 			}
 
 			return;
@@ -983,6 +984,10 @@ public class PortletExporter {
 
 		Portlet portlet = PortletLocalServiceUtil.getPortletById(
 			portletDataContext.getPortletId());
+
+		if ((portlet == null) || portlet.isUndeployedPortlet()) {
+			return;
+		}
 
 		PortletDataHandler portletDataHandler =
 			portlet.getPortletDataHandlerInstance();

--- a/portal-impl/src/com/liferay/portal/model/impl/LayoutTypePortletImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/LayoutTypePortletImpl.java
@@ -310,7 +310,7 @@ public class LayoutTypePortletImpl
 			Portlet portlet = PortletLocalServiceUtil.getPortletById(
 				getCompanyId(), portletId);
 
-			if ((portlet != null) && !portlet.isUndeployedPortlet()) {
+			if (portlet != null) {
 				portlets.add(portlet);
 			}
 		}

--- a/portal-impl/test/integration/com/liferay/portal/model/impl/LayoutTypePortletTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/model/impl/LayoutTypePortletTest.java
@@ -293,7 +293,7 @@ public class LayoutTypePortletTest {
 		try {
 			portlets = _layoutTypePortlet.getAllPortlets();
 
-			Assert.assertTrue(portlets.isEmpty());
+			Assert.assertEquals(1, portlets.size());
 		}
 		finally {
 			ReflectionTestUtil.setFieldValue(


### PR DESCRIPTION
Hi Máté,

I fixed the failing test. It still expected that undeployed portlets will be removed from the page, which is not the case anymore.

Regards,
Giros