### PR TITLE
LPS-55020

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/lar/FileEntryStagedModelDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/lar/FileEntryStagedModelDataHandler.java
@@ -751,32 +751,13 @@ public class FileEntryStagedModelDataHandler
 			}
 		}
 
-		TrashHandler trashHandler = TrashHandlerRegistryUtil.getTrashHandler(
-			DLFileEntry.class.getName());
+		if (fileEntry.isInTrash() || fileEntry.isInTrashContainer()) {
+			PortletDataException pde = new PortletDataException(
+				PortletDataException.STATUS_IN_TRASH);
 
-		if (trashHandler != null) {
-			try {
-				if (trashHandler.isInTrash(fileEntry.getFileEntryId()) ||
-					trashHandler.isInTrashContainer(
-						fileEntry.getFileEntryId())) {
+			pde.setStagedModel(fileEntry);
 
-					throw new PortletDataException(
-						PortletDataException.STATUS_IN_TRASH);
-				}
-			}
-			catch (PortletDataException pde) {
-				throw pde;
-			}
-			catch (Exception e) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(e, e);
-				}
-				else if (_log.isWarnEnabled()) {
-					_log.warn(
-						"Unable to check trash status for file entry " +
-							fileEntry.getFileEntryId());
-				}
-			}
+			throw pde;
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/lar/FolderStagedModelDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/lar/FolderStagedModelDataHandler.java
@@ -22,8 +22,6 @@ import com.liferay.portal.kernel.lar.PortletDataContext;
 import com.liferay.portal.kernel.lar.PortletDataException;
 import com.liferay.portal.kernel.lar.StagedModelDataHandlerUtil;
 import com.liferay.portal.kernel.lar.StagedModelModifiedDateComparator;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.trash.TrashHandler;
 import com.liferay.portal.kernel.trash.TrashHandlerRegistryUtil;
@@ -459,35 +457,20 @@ public class FolderStagedModelDataHandler
 			throw pde;
 		}
 
-		TrashHandler trashHandler = TrashHandlerRegistryUtil.getTrashHandler(
-			DLFolder.class.getName());
+		if (folder instanceof LiferayFolder) {
+			LiferayFolder liferayFolder = (LiferayFolder)folder;
 
-		if (trashHandler != null) {
-			try {
-				if (trashHandler.isInTrash(folder.getFolderId()) ||
-					trashHandler.isInTrashContainer(folder.getFolderId())) {
+			DLFolder dlFolder = (DLFolder)liferayFolder.getModel();
 
-					throw new PortletDataException(
-						PortletDataException.STATUS_IN_TRASH);
-				}
-			}
-			catch (PortletDataException pde) {
+			if (dlFolder.isInTrash() || dlFolder.isInTrashContainer()) {
+				PortletDataException pde = new PortletDataException(
+					PortletDataException.STATUS_IN_TRASH);
+
+				pde.setStagedModel(folder);
+
 				throw pde;
-			}
-			catch (Exception e) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(e, e);
-				}
-				else if (_log.isWarnEnabled()) {
-					_log.warn(
-						"Unable to check trash status for folder " +
-							folder.getFolderId());
-				}
 			}
 		}
 	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		FolderStagedModelDataHandler.class);
 
 }


### PR DESCRIPTION
Hi Máté,

The root cause of the **PermissionChecker not initialized** error reported at this LPS it seems to have other root cause (some thread issues that i am investigating related with LPS-54672)

But we are throwing this exceptions at log because we are using the TrashHandler class instead delegating the trash checks to the isTrash / isTrashContainer methods.

With this modifications we avoid manage the exceptions that TrashHandler throws and simplify all the code.