### PR TITLE
Asset Publisher export / import

### DIFF
--- a/modules/apps/asset/asset-publisher-test/test/integration/com/liferay/asset/publisher/lar/AssetPublisherExportImportTest.java
+++ b/modules/apps/asset/asset-publisher-test/test/integration/com/liferay/asset/publisher/lar/AssetPublisherExportImportTest.java
@@ -17,6 +17,7 @@ package com.liferay.asset.publisher.lar;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.asset.publisher.web.constants.AssetPublisherPortletKeys;
 import com.liferay.asset.publisher.web.util.AssetPublisherUtil;
+import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.portal.kernel.lar.ExportImportHelperUtil;
 import com.liferay.portal.kernel.lar.PortletDataHandlerKeys;
 import com.liferay.portal.kernel.lar.exportimportconfiguration.ExportImportConfigurationConstants;
@@ -44,6 +45,9 @@ import com.liferay.portal.model.Group;
 import com.liferay.portal.model.Layout;
 import com.liferay.portal.model.PortletInstance;
 import com.liferay.portal.model.User;
+import com.liferay.portal.security.permission.PermissionChecker;
+import com.liferay.portal.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.security.permission.PermissionThreadLocal;
 import com.liferay.portal.service.CompanyLocalServiceUtil;
 import com.liferay.portal.service.ExportImportConfigurationLocalServiceUtil;
 import com.liferay.portal.service.ExportImportLocalServiceUtil;
@@ -55,8 +59,10 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.util.PortalUtil;
 import com.liferay.portal.util.test.LayoutTestUtil;
 import com.liferay.portlet.asset.model.AssetCategory;
+import com.liferay.portlet.asset.model.AssetEntry;
 import com.liferay.portlet.asset.model.AssetVocabulary;
 import com.liferay.portlet.asset.service.AssetCategoryLocalServiceUtil;
+import com.liferay.portlet.asset.service.AssetEntryLocalServiceUtil;
 import com.liferay.portlet.asset.service.AssetVocabularyLocalServiceUtil;
 import com.liferay.portlet.asset.util.test.AssetTestUtil;
 import com.liferay.portlet.documentlibrary.model.DLFileEntry;
@@ -68,6 +74,7 @@ import com.liferay.portlet.journal.model.JournalArticle;
 
 import java.io.Serializable;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -81,6 +88,8 @@ import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.portlet.MockPortletRequest;
 
 /**
  * @author Julio Camarero
@@ -112,6 +121,9 @@ public class AssetPublisherExportImportTest
 		super.setUp();
 
 		ServiceTestUtil.setUser(TestPropsValues.getUser());
+
+		_permissionChecker = PermissionCheckerFactoryUtil.create(
+			TestPropsValues.getUser());
 	}
 
 	@Test
@@ -260,10 +272,58 @@ public class AssetPublisherExportImportTest
 				portletPreferences.getValue("displayStyle", null)));
 	}
 
+	@Test
+	public void testExportImportAssetEntries() throws Exception {
+		testExportImportAssetEntries(group);
+	}
+
 	@Ignore()
 	@Override
 	@Test
 	public void testExportImportAssetLinks() throws Exception {
+	}
+
+	@Test
+	public void testExportImportLayoutScopedAssetEntries() throws Exception {
+		Group layoutGroup = GroupTestUtil.addGroup(
+			TestPropsValues.getUserId(), layout);
+
+		testExportImportAssetEntries(layoutGroup);
+	}
+
+	@Test
+	public void testExportImportSeveralScopedAssetEntries() throws Exception {
+		List<Group> groups = new ArrayList<>();
+
+		groups.add(group);
+
+		Company company = CompanyLocalServiceUtil.getCompany(
+			layout.getCompanyId());
+
+		Group companyGroup = company.getGroup();
+
+		groups.add(companyGroup);
+
+		Group otherGroup = GroupTestUtil.addGroup();
+
+		groups.add(otherGroup);
+
+		Group layoutGroup1 = GroupTestUtil.addGroup(
+			TestPropsValues.getUserId(), layout);
+
+		Layout layout2 = LayoutTestUtil.addLayout(group);
+		Group layoutGroup2 = GroupTestUtil.addGroup(
+			TestPropsValues.getUserId(), layout2);
+
+		Layout layout3 = LayoutTestUtil.addLayout(group);
+		Group layoutGroup3 = GroupTestUtil.addGroup(
+			TestPropsValues.getUserId(), layout3);
+
+		groups.add(layoutGroup1);
+		groups.add(layoutGroup2);
+		groups.add(layoutGroup3);
+
+		testExportImportAssetEntries(groups);
 	}
 
 	@Test
@@ -678,6 +738,24 @@ public class AssetPublisherExportImportTest
 		testSortByAssetVocabulary(true);
 	}
 
+	protected List<AssetEntry> addAssetEntries(
+			Group group, int count, List<AssetEntry> assetEntries)
+		throws Exception {
+
+		for (int i = 0; i < count; i++) {
+			JournalArticle article = JournalTestUtil.addArticle(
+				group.getGroupId(), RandomTestUtil.randomString(),
+				RandomTestUtil.randomString(100));
+
+			AssetEntry assetEntry = AssetEntryLocalServiceUtil.getEntry(
+				JournalArticle.class.getName(), article.getResourcePrimKey());
+
+			assetEntries.add(assetEntry);
+		}
+
+		return assetEntries;
+	}
+
 	protected DLFileEntryType addDLFileEntryType(
 			long groupId, long ddmStructureId, ServiceContext serviceContext)
 		throws Exception {
@@ -686,6 +764,27 @@ public class AssetPublisherExportImportTest
 			serviceContext.getUserId(), groupId, RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), new long[] {ddmStructureId},
 			serviceContext);
+	}
+
+	protected void assertAssetEntries(
+		List<AssetEntry> expectedAssetEntries,
+		List<AssetEntry> actualAssetEntries) {
+
+		Assert.assertEquals(
+			expectedAssetEntries.size(), actualAssetEntries.size());
+
+		for (int i = 0; i < expectedAssetEntries.size(); i++) {
+			AssetEntry expectedAssetEntry = expectedAssetEntries.get(i);
+			AssetEntry actualAssetEntry = actualAssetEntries.get(i);
+
+			Assert.assertEquals(
+				expectedAssetEntry.getClassName(),
+				actualAssetEntry.getClassName());
+
+			Assert.assertEquals(
+				expectedAssetEntry.getClassUuid(),
+				actualAssetEntry.getClassUuid());
+		}
 	}
 
 	@Override
@@ -741,6 +840,29 @@ public class AssetPublisherExportImportTest
 		Assert.assertNotNull(importedLayout);
 	}
 
+	protected String getAssetEntryXml(AssetEntry assetEntry) {
+		StringBuilder sb = new StringBuilder(6);
+
+		sb.append("<?xml version=\"1.0\"?><asset-entry>");
+		sb.append("<asset-entry-type>");
+		sb.append(assetEntry.getClassName());
+		sb.append("</asset-entry-type><asset-entry-uuid>");
+		sb.append(assetEntry.getClassUuid());
+		sb.append("</asset-entry-uuid></asset-entry>");
+
+		return sb.toString();
+	}
+
+	protected String[] getAssetEntryXmls(List<AssetEntry> assetEntries) {
+		String[] assetEntryXmls = new String[assetEntries.size()];
+
+		for (int i = 0; i < assetEntries.size(); i++) {
+			assetEntryXmls[i] = getAssetEntryXml(assetEntries.get(i));
+		}
+
+		return assetEntryXmls;
+	}
+
 	@Override
 	protected Map<String, String[]> getExportParameterMap() throws Exception {
 		Map<String, String[]> parameterMap = new HashMap<>();
@@ -761,9 +883,70 @@ public class AssetPublisherExportImportTest
 		return parameterMap;
 	}
 
+	protected long[] getGroupIdsFromScopeIds(String[] scopeIds, Layout layout)
+		throws Exception {
+
+		long[] groupIds = new long[scopeIds.length];
+
+		for (int i = 0; i < scopeIds.length; i++) {
+			groupIds[i] = AssetPublisherUtil.getGroupIdFromScopeId(
+				scopeIds[i], layout.getGroupId(), layout.isPrivateLayout());
+		}
+
+		return groupIds;
+	}
+
 	@Override
 	protected Map<String, String[]> getImportParameterMap() throws Exception {
 		return getExportParameterMap();
+	}
+
+	protected void testExportImportAssetEntries(Group group) throws Exception {
+		List<Group> groups = new ArrayList<>();
+
+		groups.add(group);
+
+		testExportImportAssetEntries(groups);
+	}
+
+	protected void testExportImportAssetEntries(List<Group> groups)
+		throws Exception {
+
+		List<AssetEntry> assetEntries = new ArrayList<>();
+		String[] scopeIds = new String[0];
+
+		for (Group selectedGroup : groups) {
+			assetEntries = addAssetEntries(selectedGroup, 3, assetEntries);
+
+			String scopeId = AssetPublisherUtil.getScopeId(
+				selectedGroup, group.getGroupId());
+
+			scopeIds = ArrayUtil.append(scopeIds, scopeId);
+		}
+
+		Map<String, String[]> preferenceMap = new HashMap<>();
+
+		String[] assetEntryXmls = getAssetEntryXmls(assetEntries);
+
+		preferenceMap.put("assetEntryXml", assetEntryXmls);
+		preferenceMap.put("scopeIds", scopeIds);
+
+		PortletPreferences importedPortletPreferences =
+			getImportedPortletPreferences(preferenceMap);
+
+		String[] importedScopeIds = importedPortletPreferences.getValues(
+			"scopeIds", null);
+
+		long[] selectedGroupIds = getGroupIdsFromScopeIds(
+			importedScopeIds, importedLayout);
+
+		List<AssetEntry> currentAssetEntries =
+			AssetPublisherUtil.getAssetEntries(
+				new MockPortletRequest(), importedPortletPreferences,
+				PermissionThreadLocal.getPermissionChecker(), selectedGroupIds,
+				false, false);
+
+		assertAssetEntries(assetEntries, currentAssetEntries);
 	}
 
 	protected void testSortByAssetVocabulary(boolean globalVocabulary)
@@ -821,5 +1004,7 @@ public class AssetPublisherExportImportTest
 
 		AssetVocabularyLocalServiceUtil.deleteAssetVocabulary(assetVocabulary);
 	}
+
+	private PermissionChecker _permissionChecker;
 
 }

--- a/modules/apps/asset/asset-publisher-web/src/com/liferay/asset/publisher/web/lar/AssetPublisherPortletDataHandler.java
+++ b/modules/apps/asset/asset-publisher-web/src/com/liferay/asset/publisher/web/lar/AssetPublisherPortletDataHandler.java
@@ -99,10 +99,13 @@ public class AssetPublisherPortletDataHandler
 			PortletPreferences portletPreferences)
 		throws Exception {
 
+		PortletPreferences updatedportletPreferences =
+			updateImportPortletPreferences(
+				portletDataContext, portletId, portletPreferences);
+
 		importAssetEntries(portletDataContext, portletPreferences);
 
-		return updateImportPortletPreferences(
-			portletDataContext, portletId, portletPreferences);
+		return updatedportletPreferences;
 	}
 
 	protected void exportAssetEntries(

--- a/modules/apps/asset/asset-publisher-web/src/com/liferay/asset/publisher/web/lar/AssetPublisherPortletDataHandler.java
+++ b/modules/apps/asset/asset-publisher-web/src/com/liferay/asset/publisher/web/lar/AssetPublisherPortletDataHandler.java
@@ -36,6 +36,7 @@ import com.liferay.portal.model.Company;
 import com.liferay.portal.model.Group;
 import com.liferay.portal.model.Layout;
 import com.liferay.portal.model.Portlet;
+import com.liferay.portal.model.StagedModel;
 import com.liferay.portal.security.auth.PrincipalException;
 import com.liferay.portal.security.permission.PermissionThreadLocal;
 import com.liferay.portal.service.CompanyLocalServiceUtil;
@@ -45,6 +46,7 @@ import com.liferay.portal.util.PortalUtil;
 import com.liferay.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portlet.asset.model.AssetCategory;
 import com.liferay.portlet.asset.model.AssetEntry;
+import com.liferay.portlet.asset.model.AssetRenderer;
 import com.liferay.portlet.asset.model.AssetVocabulary;
 import com.liferay.portlet.asset.service.AssetCategoryLocalServiceUtil;
 import com.liferay.portlet.asset.service.AssetVocabularyLocalServiceUtil;
@@ -85,6 +87,8 @@ public class AssetPublisherPortletDataHandler
 			PortletPreferences portletPreferences)
 		throws Exception {
 
+		exportAssetEntries(portletDataContext, portletPreferences);
+
 		return updateExportPortletPreferences(
 			portletDataContext, portletId, portletPreferences);
 	}
@@ -95,8 +99,41 @@ public class AssetPublisherPortletDataHandler
 			PortletPreferences portletPreferences)
 		throws Exception {
 
+		importAssetEntries(portletDataContext, portletPreferences);
+
 		return updateImportPortletPreferences(
 			portletDataContext, portletId, portletPreferences);
+	}
+
+	protected void exportAssetEntries(
+			PortletDataContext portletDataContext,
+			PortletPreferences portletPreferences)
+		throws Exception {
+
+		Layout layout = LayoutLocalServiceUtil.getLayout(
+			portletDataContext.getPlid());
+
+		long[] groupIds = AssetPublisherUtil.getGroupIds(
+			portletPreferences, portletDataContext.getScopeGroupId(), layout);
+
+		List<AssetEntry> assetEntries = AssetPublisherUtil.getAssetEntries(
+			null, portletPreferences,
+			PermissionThreadLocal.getPermissionChecker(), groupIds, false,
+			false);
+
+		for (AssetEntry assetEntry : assetEntries) {
+			AssetRenderer assetRenderer = assetEntry.getAssetRenderer();
+
+			if ((assetRenderer == null) ||
+				!(assetRenderer.getEntry() instanceof StagedModel)) {
+
+				continue;
+			}
+
+			StagedModelDataHandlerUtil.exportReferenceStagedModel(
+				portletDataContext, portletDataContext.getPortletId(),
+				(StagedModel)assetRenderer.getEntry());
+		}
 	}
 
 	@Override
@@ -138,6 +175,15 @@ public class AssetPublisherPortletDataHandler
 		}
 
 		return 0;
+	}
+
+	protected void importAssetEntries(
+			PortletDataContext portletDataContext,
+			PortletPreferences portletPreferences)
+		throws Exception {
+
+		StagedModelDataHandlerUtil.importReferenceStagedModels(
+			portletDataContext, null);
 	}
 
 	protected void restorePortletPreference(

--- a/modules/apps/asset/asset-publisher-web/src/com/liferay/asset/publisher/web/lar/AssetPublisherPortletDataHandler.java
+++ b/modules/apps/asset/asset-publisher-web/src/com/liferay/asset/publisher/web/lar/AssetPublisherPortletDataHandler.java
@@ -183,7 +183,7 @@ public class AssetPublisherPortletDataHandler
 		throws Exception {
 
 		StagedModelDataHandlerUtil.importReferenceStagedModels(
-			portletDataContext, null);
+			portletDataContext, null, true);
 	}
 
 	protected void restorePortletPreference(

--- a/modules/apps/asset/asset-publisher-web/src/com/liferay/asset/publisher/web/lar/AssetPublisherPortletDataHandler.java
+++ b/modules/apps/asset/asset-publisher-web/src/com/liferay/asset/publisher/web/lar/AssetPublisherPortletDataHandler.java
@@ -18,7 +18,6 @@ import com.liferay.asset.publisher.web.constants.AssetPublisherPortletKeys;
 import com.liferay.asset.publisher.web.util.AssetPublisherUtil;
 import com.liferay.portal.NoSuchGroupException;
 import com.liferay.portal.NoSuchLayoutException;
-import com.liferay.portal.ResourceBlocksNotSupportedException;
 import com.liferay.portal.kernel.lar.DataLevel;
 import com.liferay.portal.kernel.lar.DefaultConfigurationPortletDataHandler;
 import com.liferay.portal.kernel.lar.ExportImportHelperUtil;
@@ -36,16 +35,12 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.model.Company;
 import com.liferay.portal.model.Group;
 import com.liferay.portal.model.Layout;
-import com.liferay.portal.model.PermissionedModel;
-import com.liferay.portal.model.PersistedModel;
 import com.liferay.portal.model.Portlet;
 import com.liferay.portal.model.StagedModel;
 import com.liferay.portal.security.auth.PrincipalException;
 import com.liferay.portal.security.permission.PermissionThreadLocal;
 import com.liferay.portal.service.CompanyLocalServiceUtil;
 import com.liferay.portal.service.LayoutLocalServiceUtil;
-import com.liferay.portal.service.PersistedModelLocalService;
-import com.liferay.portal.service.PersistedModelLocalServiceRegistryUtil;
 import com.liferay.portal.service.PortletLocalServiceUtil;
 import com.liferay.portal.util.PortalUtil;
 import com.liferay.portlet.PortletPreferencesFactoryUtil;
@@ -132,29 +127,15 @@ public class AssetPublisherPortletDataHandler
 		for (AssetEntry assetEntry : assetEntries) {
 			AssetRenderer assetRenderer = assetEntry.getAssetRenderer();
 
-			if (assetRenderer == null) {
-				continue;
-			}
+			if ((assetRenderer == null) ||
+				!(assetRenderer.getEntry() instanceof StagedModel)) {
 
-			PersistedModelLocalService persistedModelLocalService =
-				PersistedModelLocalServiceRegistryUtil.
-					getPersistedModelLocalService(assetRenderer.getClassName());
-
-			if (persistedModelLocalService == null) {
-				continue;
-			}
-
-			PersistedModel persistedModel =
-				persistedModelLocalService.getPersistedModel(
-					assetRenderer.getClassPK());
-
-			if (!(persistedModel instanceof StagedModel)) {
 				continue;
 			}
 
 			StagedModelDataHandlerUtil.exportReferenceStagedModel(
 				portletDataContext, portletDataContext.getPortletId(),
-				(StagedModel)persistedModel);
+				(StagedModel)assetRenderer.getEntry());
 		}
 	}
 

--- a/modules/apps/asset/asset-publisher-web/src/com/liferay/asset/publisher/web/lar/AssetPublisherPortletDataHandler.java
+++ b/modules/apps/asset/asset-publisher-web/src/com/liferay/asset/publisher/web/lar/AssetPublisherPortletDataHandler.java
@@ -18,6 +18,7 @@ import com.liferay.asset.publisher.web.constants.AssetPublisherPortletKeys;
 import com.liferay.asset.publisher.web.util.AssetPublisherUtil;
 import com.liferay.portal.NoSuchGroupException;
 import com.liferay.portal.NoSuchLayoutException;
+import com.liferay.portal.ResourceBlocksNotSupportedException;
 import com.liferay.portal.kernel.lar.DataLevel;
 import com.liferay.portal.kernel.lar.DefaultConfigurationPortletDataHandler;
 import com.liferay.portal.kernel.lar.ExportImportHelperUtil;
@@ -35,12 +36,16 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.model.Company;
 import com.liferay.portal.model.Group;
 import com.liferay.portal.model.Layout;
+import com.liferay.portal.model.PermissionedModel;
+import com.liferay.portal.model.PersistedModel;
 import com.liferay.portal.model.Portlet;
 import com.liferay.portal.model.StagedModel;
 import com.liferay.portal.security.auth.PrincipalException;
 import com.liferay.portal.security.permission.PermissionThreadLocal;
 import com.liferay.portal.service.CompanyLocalServiceUtil;
 import com.liferay.portal.service.LayoutLocalServiceUtil;
+import com.liferay.portal.service.PersistedModelLocalService;
+import com.liferay.portal.service.PersistedModelLocalServiceRegistryUtil;
 import com.liferay.portal.service.PortletLocalServiceUtil;
 import com.liferay.portal.util.PortalUtil;
 import com.liferay.portlet.PortletPreferencesFactoryUtil;
@@ -127,15 +132,29 @@ public class AssetPublisherPortletDataHandler
 		for (AssetEntry assetEntry : assetEntries) {
 			AssetRenderer assetRenderer = assetEntry.getAssetRenderer();
 
-			if ((assetRenderer == null) ||
-				!(assetRenderer.getEntry() instanceof StagedModel)) {
+			if (assetRenderer == null) {
+				continue;
+			}
 
+			PersistedModelLocalService persistedModelLocalService =
+				PersistedModelLocalServiceRegistryUtil.
+					getPersistedModelLocalService(assetRenderer.getClassName());
+
+			if (persistedModelLocalService == null) {
+				continue;
+			}
+
+			PersistedModel persistedModel =
+				persistedModelLocalService.getPersistedModel(
+					assetRenderer.getClassPK());
+
+			if (!(persistedModel instanceof StagedModel)) {
 				continue;
 			}
 
 			StagedModelDataHandlerUtil.exportReferenceStagedModel(
 				portletDataContext, portletDataContext.getPortletId(),
-				(StagedModel)assetRenderer.getEntry());
+				(StagedModel)persistedModel);
 		}
 	}
 

--- a/modules/apps/bookmarks/bookmarks-service/src/com/liferay/bookmarks/asset/BookmarksEntryAssetRenderer.java
+++ b/modules/apps/bookmarks/bookmarks-service/src/com/liferay/bookmarks/asset/BookmarksEntryAssetRenderer.java
@@ -64,6 +64,11 @@ public class BookmarksEntryAssetRenderer
 	}
 
 	@Override
+	public Object getEntry() {
+		return _entry;
+	}
+
+	@Override
 	public long getGroupId() {
 		return _entry.getGroupId();
 	}

--- a/modules/apps/bookmarks/bookmarks-service/src/com/liferay/bookmarks/asset/BookmarksFolderAssetRenderer.java
+++ b/modules/apps/bookmarks/bookmarks-service/src/com/liferay/bookmarks/asset/BookmarksFolderAssetRenderer.java
@@ -70,6 +70,11 @@ public class BookmarksFolderAssetRenderer
 	}
 
 	@Override
+	public Object getEntry() {
+		return _folder;
+	}
+
+	@Override
 	public long getGroupId() {
 		return _folder.getGroupId();
 	}

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/com/liferay/dynamic/data/lists/web/asset/DDLRecordAssetRenderer.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/com/liferay/dynamic/data/lists/web/asset/DDLRecordAssetRenderer.java
@@ -87,6 +87,11 @@ public class DDLRecordAssetRenderer extends BaseAssetRenderer {
 	}
 
 	@Override
+	public Object getEntry() {
+		return _record;
+	}
+
+	@Override
 	public long getGroupId() {
 		return _record.getGroupId();
 	}

--- a/modules/apps/journal/journal-test/test/integration/com/liferay/journal/test/util/JournalTestUtil.java
+++ b/modules/apps/journal/journal-test/test/integration/com/liferay/journal/test/util/JournalTestUtil.java
@@ -37,8 +37,10 @@ import com.liferay.portal.kernel.xml.Node;
 import com.liferay.portal.kernel.xml.SAXReaderUtil;
 import com.liferay.portal.kernel.xml.UnsecureSAXReaderUtil;
 import com.liferay.portal.kernel.xml.XPath;
+import com.liferay.portal.model.Company;
 import com.liferay.portal.model.Group;
 import com.liferay.portal.model.Layout;
+import com.liferay.portal.service.CompanyLocalServiceUtil;
 import com.liferay.portal.service.GroupLocalServiceUtil;
 import com.liferay.portal.service.LayoutLocalServiceUtil;
 import com.liferay.portal.service.ServiceContext;
@@ -152,11 +154,24 @@ public class JournalTestUtil {
 		DDMForm ddmForm = DDMStructureTestUtil.getSampleDDMForm(
 			_locales, defaultLocale);
 
+		long ddmGroupId = groupId;
+
+		Group group = GroupLocalServiceUtil.getGroup(groupId);
+
+		if (group.isLayout()) {
+			Company company = CompanyLocalServiceUtil.getCompany(
+				TestPropsValues.getCompanyId());
+
+			Group companyGroup = company.getGroup();
+
+			ddmGroupId = companyGroup.getGroupId();
+		}
+
 		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
-			groupId, JournalArticle.class.getName(), ddmForm, defaultLocale);
+			ddmGroupId, JournalArticle.class.getName(), ddmForm, defaultLocale);
 
 		DDMTemplate ddmTemplate = DDMTemplateTestUtil.addTemplate(
-			groupId, ddmStructure.getStructureId());
+			ddmGroupId, ddmStructure.getStructureId());
 
 		boolean neverExpire = true;
 

--- a/modules/apps/journal/journal-web/src/com/liferay/journal/web/asset/JournalArticleAssetRenderer.java
+++ b/modules/apps/journal/journal-web/src/com/liferay/journal/web/asset/JournalArticleAssetRenderer.java
@@ -122,6 +122,11 @@ public class JournalArticleAssetRenderer
 	}
 
 	@Override
+	public Object getEntry() {
+		return _article;
+	}
+
+	@Override
 	public long getGroupId() {
 		return _article.getGroupId();
 	}

--- a/modules/apps/journal/journal-web/src/com/liferay/journal/web/asset/JournalFolderAssetRenderer.java
+++ b/modules/apps/journal/journal-web/src/com/liferay/journal/web/asset/JournalFolderAssetRenderer.java
@@ -69,6 +69,11 @@ public class JournalFolderAssetRenderer
 	}
 
 	@Override
+	public Object getEntry() {
+		return _folder;
+	}
+
+	@Override
 	public long getGroupId() {
 		return _folder.getGroupId();
 	}

--- a/modules/apps/wiki/wiki-service/src/com/liferay/wiki/asset/WikiPageAssetRenderer.java
+++ b/modules/apps/wiki/wiki-service/src/com/liferay/wiki/asset/WikiPageAssetRenderer.java
@@ -109,6 +109,11 @@ public class WikiPageAssetRenderer
 	}
 
 	@Override
+	public Object getEntry() {
+		return _page;
+	}
+
+	@Override
 	public long getGroupId() {
 		return _page.getGroupId();
 	}

--- a/portal-impl/src/com/liferay/portal/asset/LayoutAssetRenderer.java
+++ b/portal-impl/src/com/liferay/portal/asset/LayoutAssetRenderer.java
@@ -51,6 +51,11 @@ public class LayoutAssetRenderer extends BaseAssetRenderer {
 	}
 
 	@Override
+	public Object getEntry() {
+		return _layout;
+	}
+
+	@Override
 	public long getGroupId() {
 		return _layout.getGroupId();
 	}

--- a/portal-impl/src/com/liferay/portal/asset/LayoutRevisionAssetRenderer.java
+++ b/portal-impl/src/com/liferay/portal/asset/LayoutRevisionAssetRenderer.java
@@ -67,6 +67,11 @@ public class LayoutRevisionAssetRenderer extends BaseAssetRenderer {
 	}
 
 	@Override
+	public Object getEntry() {
+		return _layoutRevision;
+	}
+
+	@Override
 	public long getGroupId() {
 		return _layoutRevision.getGroupId();
 	}

--- a/portal-impl/src/com/liferay/portal/lar/PortletDataContextImpl.java
+++ b/portal-impl/src/com/liferay/portal/lar/PortletDataContextImpl.java
@@ -77,6 +77,7 @@ import com.liferay.portal.model.StagedModel;
 import com.liferay.portal.model.Team;
 import com.liferay.portal.security.permission.ResourceActionsUtil;
 import com.liferay.portal.service.GroupLocalServiceUtil;
+import com.liferay.portal.service.LayoutLocalServiceUtil;
 import com.liferay.portal.service.ResourceBlockLocalServiceUtil;
 import com.liferay.portal.service.ResourceBlockPermissionLocalServiceUtil;
 import com.liferay.portal.service.ResourcePermissionLocalServiceUtil;
@@ -2145,6 +2146,14 @@ public class PortletDataContextImpl implements PortletDataContext {
 
 				referenceElement.addAttribute(
 					"live-group-id", String.valueOf(liveGroupId));
+
+				if (group.isLayout()) {
+					Layout layout = LayoutLocalServiceUtil.getLayout(
+						group.getClassPK());
+
+					referenceElement.addAttribute(
+						"scope-layout-uuid", layout.getUuid());
+				}
 			}
 			catch (Exception e) {
 				if (_log.isWarnEnabled()) {

--- a/portal-impl/src/com/liferay/portlet/blogs/asset/BlogsEntryAssetRenderer.java
+++ b/portal-impl/src/com/liferay/portlet/blogs/asset/BlogsEntryAssetRenderer.java
@@ -77,6 +77,11 @@ public class BlogsEntryAssetRenderer
 	}
 
 	@Override
+	public Object getEntry() {
+		return _entry;
+	}
+
+	@Override
 	public long getGroupId() {
 		return _entry.getGroupId();
 	}

--- a/portal-impl/src/com/liferay/portlet/directory/asset/UserAssetRenderer.java
+++ b/portal-impl/src/com/liferay/portlet/directory/asset/UserAssetRenderer.java
@@ -57,6 +57,11 @@ public class UserAssetRenderer extends BaseAssetRenderer {
 	}
 
 	@Override
+	public Object getEntry() {
+		return _user;
+	}
+
+	@Override
 	public long getGroupId() {
 		return 0;
 	}

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/asset/DLFileEntryAssetRenderer.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/asset/DLFileEntryAssetRenderer.java
@@ -106,6 +106,11 @@ public class DLFileEntryAssetRenderer
 	}
 
 	@Override
+	public Object getEntry() {
+		return _fileEntry;
+	}
+
+	@Override
 	public long getGroupId() {
 		return _fileEntry.getGroupId();
 	}

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/asset/DLFolderAssetRenderer.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/asset/DLFolderAssetRenderer.java
@@ -73,6 +73,11 @@ public class DLFolderAssetRenderer
 	}
 
 	@Override
+	public Object getEntry() {
+		return _folder;
+	}
+
+	@Override
 	public long getGroupId() {
 		return _folder.getGroupId();
 	}

--- a/portal-impl/src/com/liferay/portlet/messageboards/asset/MBCategoryAssetRenderer.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/asset/MBCategoryAssetRenderer.java
@@ -57,6 +57,11 @@ public class MBCategoryAssetRenderer extends BaseAssetRenderer {
 	}
 
 	@Override
+	public Object getEntry() {
+		return _category;
+	}
+
+	@Override
 	public long getGroupId() {
 		return _category.getGroupId();
 	}

--- a/portal-impl/src/com/liferay/portlet/messageboards/asset/MBDiscussionAssetRenderer.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/asset/MBDiscussionAssetRenderer.java
@@ -41,6 +41,11 @@ public class MBDiscussionAssetRenderer extends MBMessageAssetRenderer {
 	}
 
 	@Override
+	public Object getEntry() {
+		return _message;
+	}
+
+	@Override
 	public PortletURL getURLEdit(
 			LiferayPortletRequest liferayPortletRequest,
 			LiferayPortletResponse liferayPortletResponse)

--- a/portal-impl/src/com/liferay/portlet/messageboards/asset/MBMessageAssetRenderer.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/asset/MBMessageAssetRenderer.java
@@ -67,6 +67,11 @@ public class MBMessageAssetRenderer
 	}
 
 	@Override
+	public Object getEntry() {
+		return _message;
+	}
+
+	@Override
 	public long getGroupId() {
 		return _message.getGroupId();
 	}

--- a/portal-service/src/com/liferay/portal/kernel/lar/StagedModelDataHandlerUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/lar/StagedModelDataHandlerUtil.java
@@ -16,16 +16,24 @@ package com.liferay.portal.kernel.lar;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.NoSuchGroupException;
+import com.liferay.portal.NoSuchLayoutException;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.spring.orm.LastSessionRecorderHelperUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.xml.Attribute;
 import com.liferay.portal.kernel.xml.Element;
+import com.liferay.portal.model.Group;
+import com.liferay.portal.model.Layout;
 import com.liferay.portal.model.Portlet;
 import com.liferay.portal.model.StagedModel;
 import com.liferay.portal.model.TypedModel;
+import com.liferay.portal.service.GroupLocalServiceUtil;
+import com.liferay.portal.service.LayoutLocalServiceUtil;
 import com.liferay.portal.service.PortletLocalServiceUtil;
 import com.liferay.portal.util.PortalUtil;
 
@@ -230,6 +238,15 @@ public class StagedModelDataHandlerUtil {
 			PortletDataContext portletDataContext, Class<?> stagedModelClass)
 		throws PortletDataException {
 
+		importReferenceStagedModels(
+			portletDataContext, stagedModelClass, false);
+	}
+
+	public static void importReferenceStagedModels(
+			PortletDataContext portletDataContext, Class<?> stagedModelClass,
+			boolean checkScopeGroupId)
+		throws PortletDataException {
+
 		Element importDataRootElement =
 			portletDataContext.getImportDataRootElement();
 
@@ -270,7 +287,57 @@ public class StagedModelDataHandlerUtil {
 				continue;
 			}
 
-			importStagedModel(portletDataContext, referenceElement);
+			String scopeLayoutUuid = GetterUtil.getString(
+				referenceElement.attributeValue("scope-layout-uuid"));
+
+			long previousScopeGroupId = portletDataContext.getScopeGroupId();
+
+			try {
+				if (checkScopeGroupId && Validator.isNotNull(scopeLayoutUuid)) {
+					try {
+						Layout scopeLayout =
+							LayoutLocalServiceUtil.getLayoutByUuidAndGroupId(
+								scopeLayoutUuid,
+								portletDataContext.getGroupId(),
+								portletDataContext.isPrivateLayout());
+
+						Group scopeGroup = GroupLocalServiceUtil.getLayoutGroup(
+							portletDataContext.getCompanyId(),
+							scopeLayout.getPlid());
+
+						portletDataContext.setScopeGroupId(
+							scopeGroup.getGroupId());
+					}
+					catch (NoSuchGroupException nsge) {
+						if (_log.isInfoEnabled()) {
+							_log.info(
+								"Ignoring element because the referenced " +
+									"group was not found",
+								nsge);
+						}
+
+						continue;
+					}
+					catch (NoSuchLayoutException nsle) {
+						if (_log.isInfoEnabled()) {
+							_log.info(
+								"Ignoring element because the referenced " +
+									"layout was not found",
+								nsle);
+						}
+
+						continue;
+					}
+					catch (PortalException pe) {
+						throw new PortletDataException(pe);
+					}
+				}
+
+				importStagedModel(portletDataContext, referenceElement);
+			}
+			finally {
+				portletDataContext.setScopeGroupId(previousScopeGroupId);
+			}
 		}
 	}
 
@@ -397,5 +464,8 @@ public class StagedModelDataHandlerUtil {
 
 		return stagedModelDataHandler;
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		StagedModelDataHandlerUtil.class);
 
 }

--- a/portal-service/src/com/liferay/portal/kernel/lar/StagedModelDataHandlerUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/lar/StagedModelDataHandlerUtil.java
@@ -243,10 +243,13 @@ public class StagedModelDataHandlerUtil {
 
 		for (Element referenceElement : referenceElements) {
 			String className = referenceElement.attributeValue("class-name");
-			String stagedModelClassName = stagedModelClass.getName();
 
-			if (!stagedModelClassName.equals(className)) {
-				continue;
+			if (stagedModelClass != null) {
+				String stagedModelClassName = stagedModelClass.getName();
+
+				if (!stagedModelClassName.equals(className)) {
+					continue;
+				}
 			}
 
 			boolean missing = GetterUtil.getBoolean(
@@ -254,7 +257,7 @@ public class StagedModelDataHandlerUtil {
 
 			StagedModelDataHandler<?> stagedModelDataHandler =
 				StagedModelDataHandlerRegistryUtil.getStagedModelDataHandler(
-					stagedModelClassName);
+					className);
 
 			if (stagedModelDataHandler == null) {
 				continue;

--- a/portal-service/src/com/liferay/portlet/asset/model/AssetRenderer.java
+++ b/portal-service/src/com/liferay/portlet/asset/model/AssetRenderer.java
@@ -63,6 +63,8 @@ public interface AssetRenderer extends Renderer {
 
 	public Date getDisplayDate();
 
+	public Object getEntry();
+
 	public long getGroupId();
 
 	public String getNewName(String oldName, String token);

--- a/portal-service/src/com/liferay/portlet/asset/model/BaseAssetRenderer.java
+++ b/portal-service/src/com/liferay/portlet/asset/model/BaseAssetRenderer.java
@@ -113,6 +113,11 @@ public abstract class BaseAssetRenderer implements AssetRenderer {
 	}
 
 	@Override
+	public Object getEntry() {
+		return null;
+	}
+
+	@Override
 	@SuppressWarnings("unused")
 	public String getIconCssClass() throws PortalException {
 		return getAssetRendererFactory().getIconCssClass();


### PR DESCRIPTION
Hey Máté,

this pr is about the Asset Publisher export/import functionality.

As a limitation, it only works when the Asset Publisher is configured to **Manual** asset selection.
It's because we don't have a clear API for getting the Asset Entries yet.
However, when we will have that, it will fit for the current implantation, as far as it gives back an Asset Entry list. 

I checked Dani's hint about using the **PersistedModelLocalServiceRegistryUtil** (see my last commits).
I found it quite easy to use, but it won't work in all cases. 
E.g. the JournalArticleAssetRenderer.getClassPK() call will return the article's ResourcePrimKey not the PrimaryKey.

Even if I could find a way to solve this problem, I cannot see the benefits.
It looks unnatural to me that the *AssetRenderers cannot give back the current entry, that's why I kept the AssetRenderer related changes.

I considered to change the return type from Object to BaseModel for the getEntry method in the *AssetRenderers, however it doesn't work for **DLFileEntryAssetRenderer** where the returnd object doesn't implement it.

I created some tests as well.
Currently it uses the *JournalTestUtil* to create entries.
It could be easily modified, to use other types as well.

cc @zsigmondrab

