### PR TITLE
[TECHNICAL-SUPPORT] LPS-56374 Document version deletion isn't published

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/lar/FileEntryStagedModelDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/lar/FileEntryStagedModelDataHandler.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.lar.BaseStagedModelDataHandler;
 import com.liferay.portal.kernel.lar.ExportImportPathUtil;
+import com.liferay.portal.kernel.lar.ExportImportThreadLocal;
 import com.liferay.portal.kernel.lar.PortletDataContext;
 import com.liferay.portal.kernel.lar.PortletDataException;
 import com.liferay.portal.kernel.lar.StagedModelDataHandlerUtil;
@@ -448,12 +449,14 @@ public class FileEntryStagedModelDataHandler
 				boolean indexEnabled = serviceContext.isIndexingEnabled();
 
 				boolean updateFileEntry = false;
+				boolean deleteFileEntry = false;
 
 				if (!Validator.equals(
 						fileVersion.getUuid(),
 						latestExistingFileVersion.getUuid())) {
 
 					updateFileEntry = true;
+					deleteFileEntry = true;
 				}
 				else {
 					InputStream existingFileVersionInputStream = null;
@@ -527,6 +530,14 @@ public class FileEntryStagedModelDataHandler
 							DLFileEntry.class);
 
 						indexer.reindex(liferayFileEntry.getModel());
+					}
+
+					if (deleteFileEntry &&
+						ExportImportThreadLocal.isStagingInProcess()) {
+
+						DLAppServiceUtil.deleteFileVersion(
+							latestExistingFileVersion.getFileEntryId(),
+							latestExistingFileVersion.getVersion());
 					}
 				}
 				finally {

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -913,8 +913,12 @@ public class DLFileEntryLocalServiceImpl
 						dlFileVersionLocalService.getLatestFileVersion(
 							dlFileEntry.getFileEntryId(), true);
 
-					dlFileEntry.setModifiedDate(
-						dlLatestFileVersion.getCreateDate());
+					dlLatestFileVersion.setModifiedDate(new Date());
+					dlLatestFileVersion.setStatusDate(new Date());
+
+					dlFileVersionPersistence.update(dlLatestFileVersion);
+
+					dlFileEntry.setModifiedDate(new Date());
 					dlFileEntry.setFileName(dlLatestFileVersion.getFileName());
 					dlFileEntry.setExtension(
 						dlLatestFileVersion.getExtension());


### PR DESCRIPTION
Hey Máté,

as we don't have StagedModel for file versions, the staging process doesn't recognize if a version was deleted.

As we discussed, in Live only the latest approved version is used, so the other versions are unnecessarily, this fix deletes them.

I decided to modify the latest version's modified and status date during deletion, as otherwise it is not recognized by the publication process.
This change is a bit harsh, as it could affect other parts of the portal as well.
However, I can't see any other way which ensures that the latest version will be published when the date range is set to "From Last Publish Date". 
Furthermore we could say that when an entry becomes the latest approved version, it's a change as it will be the displayed entry.

Thanks,
Tamás