### PR TITLE
LPS-56418 Updating AssetRenderer with new method getEntry()

### DIFF
--- a/modules/apps/bookmarks/bookmarks-service/src/com/liferay/bookmarks/asset/BookmarksEntryAssetRenderer.java
+++ b/modules/apps/bookmarks/bookmarks-service/src/com/liferay/bookmarks/asset/BookmarksEntryAssetRenderer.java
@@ -64,6 +64,11 @@ public class BookmarksEntryAssetRenderer
 	}
 
 	@Override
+	public Object getEntry() {
+		return _entry;
+	}
+
+	@Override
 	public long getGroupId() {
 		return _entry.getGroupId();
 	}

--- a/modules/apps/bookmarks/bookmarks-service/src/com/liferay/bookmarks/asset/BookmarksFolderAssetRenderer.java
+++ b/modules/apps/bookmarks/bookmarks-service/src/com/liferay/bookmarks/asset/BookmarksFolderAssetRenderer.java
@@ -70,6 +70,11 @@ public class BookmarksFolderAssetRenderer
 	}
 
 	@Override
+	public Object getEntry() {
+		return _folder;
+	}
+
+	@Override
 	public long getGroupId() {
 		return _folder.getGroupId();
 	}

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/com/liferay/dynamic/data/lists/web/asset/DDLRecordAssetRenderer.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/com/liferay/dynamic/data/lists/web/asset/DDLRecordAssetRenderer.java
@@ -87,6 +87,11 @@ public class DDLRecordAssetRenderer extends BaseAssetRenderer {
 	}
 
 	@Override
+	public Object getEntry() {
+		return _record;
+	}
+
+	@Override
 	public long getGroupId() {
 		return _record.getGroupId();
 	}

--- a/modules/apps/journal/journal-web/src/com/liferay/journal/web/asset/JournalArticleAssetRenderer.java
+++ b/modules/apps/journal/journal-web/src/com/liferay/journal/web/asset/JournalArticleAssetRenderer.java
@@ -122,6 +122,11 @@ public class JournalArticleAssetRenderer
 	}
 
 	@Override
+	public Object getEntry() {
+		return _article;
+	}
+
+	@Override
 	public long getGroupId() {
 		return _article.getGroupId();
 	}

--- a/modules/apps/journal/journal-web/src/com/liferay/journal/web/asset/JournalFolderAssetRenderer.java
+++ b/modules/apps/journal/journal-web/src/com/liferay/journal/web/asset/JournalFolderAssetRenderer.java
@@ -69,6 +69,11 @@ public class JournalFolderAssetRenderer
 	}
 
 	@Override
+	public Object getEntry() {
+		return _folder;
+	}
+
+	@Override
 	public long getGroupId() {
 		return _folder.getGroupId();
 	}

--- a/modules/apps/layout/layout-admin-web/src/com/liferay/layout/admin/web/asset/LayoutAssetRenderer.java
+++ b/modules/apps/layout/layout-admin-web/src/com/liferay/layout/admin/web/asset/LayoutAssetRenderer.java
@@ -51,6 +51,11 @@ public class LayoutAssetRenderer extends BaseAssetRenderer {
 	}
 
 	@Override
+	public Object getEntry() {
+		return _layout;
+	}
+
+	@Override
 	public long getGroupId() {
 		return _layout.getGroupId();
 	}

--- a/modules/apps/layout/layout-admin-web/src/com/liferay/layout/admin/web/asset/LayoutRevisionAssetRenderer.java
+++ b/modules/apps/layout/layout-admin-web/src/com/liferay/layout/admin/web/asset/LayoutRevisionAssetRenderer.java
@@ -67,6 +67,11 @@ public class LayoutRevisionAssetRenderer extends BaseAssetRenderer {
 	}
 
 	@Override
+	public Object getEntry() {
+		return _layoutRevision;
+	}
+
+	@Override
 	public long getGroupId() {
 		return _layoutRevision.getGroupId();
 	}

--- a/modules/apps/wiki/wiki-service/src/com/liferay/wiki/asset/WikiPageAssetRenderer.java
+++ b/modules/apps/wiki/wiki-service/src/com/liferay/wiki/asset/WikiPageAssetRenderer.java
@@ -109,6 +109,11 @@ public class WikiPageAssetRenderer
 	}
 
 	@Override
+	public Object getEntry() {
+		return _page;
+	}
+
+	@Override
 	public long getGroupId() {
 		return _page.getGroupId();
 	}

--- a/portal-impl/src/com/liferay/portlet/blogs/asset/BlogsEntryAssetRenderer.java
+++ b/portal-impl/src/com/liferay/portlet/blogs/asset/BlogsEntryAssetRenderer.java
@@ -77,6 +77,11 @@ public class BlogsEntryAssetRenderer
 	}
 
 	@Override
+	public Object getEntry() {
+		return _entry;
+	}
+
+	@Override
 	public long getGroupId() {
 		return _entry.getGroupId();
 	}

--- a/portal-impl/src/com/liferay/portlet/directory/asset/UserAssetRenderer.java
+++ b/portal-impl/src/com/liferay/portlet/directory/asset/UserAssetRenderer.java
@@ -57,6 +57,11 @@ public class UserAssetRenderer extends BaseAssetRenderer {
 	}
 
 	@Override
+	public Object getEntry() {
+		return _user;
+	}
+
+	@Override
 	public long getGroupId() {
 		return 0;
 	}

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/asset/DLFileEntryAssetRenderer.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/asset/DLFileEntryAssetRenderer.java
@@ -106,6 +106,11 @@ public class DLFileEntryAssetRenderer
 	}
 
 	@Override
+	public Object getEntry() {
+		return _fileEntry;
+	}
+
+	@Override
 	public long getGroupId() {
 		return _fileEntry.getGroupId();
 	}

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/asset/DLFolderAssetRenderer.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/asset/DLFolderAssetRenderer.java
@@ -73,6 +73,11 @@ public class DLFolderAssetRenderer
 	}
 
 	@Override
+	public Object getEntry() {
+		return _folder;
+	}
+
+	@Override
 	public long getGroupId() {
 		return _folder.getGroupId();
 	}

--- a/portal-impl/src/com/liferay/portlet/messageboards/asset/MBCategoryAssetRenderer.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/asset/MBCategoryAssetRenderer.java
@@ -57,6 +57,11 @@ public class MBCategoryAssetRenderer extends BaseAssetRenderer {
 	}
 
 	@Override
+	public Object getEntry() {
+		return _category;
+	}
+
+	@Override
 	public long getGroupId() {
 		return _category.getGroupId();
 	}

--- a/portal-impl/src/com/liferay/portlet/messageboards/asset/MBDiscussionAssetRenderer.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/asset/MBDiscussionAssetRenderer.java
@@ -41,6 +41,11 @@ public class MBDiscussionAssetRenderer extends MBMessageAssetRenderer {
 	}
 
 	@Override
+	public Object getEntry() {
+		return _message;
+	}
+
+	@Override
 	public PortletURL getURLEdit(
 			LiferayPortletRequest liferayPortletRequest,
 			LiferayPortletResponse liferayPortletResponse)

--- a/portal-impl/src/com/liferay/portlet/messageboards/asset/MBMessageAssetRenderer.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/asset/MBMessageAssetRenderer.java
@@ -67,6 +67,11 @@ public class MBMessageAssetRenderer
 	}
 
 	@Override
+	public Object getEntry() {
+		return _message;
+	}
+
+	@Override
 	public long getGroupId() {
 		return _message.getGroupId();
 	}

--- a/portal-service/src/com/liferay/portlet/asset/model/AssetRenderer.java
+++ b/portal-service/src/com/liferay/portlet/asset/model/AssetRenderer.java
@@ -63,6 +63,8 @@ public interface AssetRenderer extends Renderer {
 
 	public Date getDisplayDate();
 
+	public Object getEntry();
+
 	public long getGroupId();
 
 	public String getNewName(String oldName, String token);

--- a/portal-service/src/com/liferay/portlet/asset/model/BaseAssetRenderer.java
+++ b/portal-service/src/com/liferay/portlet/asset/model/BaseAssetRenderer.java
@@ -113,6 +113,11 @@ public abstract class BaseAssetRenderer implements AssetRenderer {
 	}
 
 	@Override
+	public Object getEntry() {
+		return null;
+	}
+
+	@Override
 	@SuppressWarnings("unused")
 	public String getIconCssClass() throws PortalException {
 		return getAssetRendererFactory().getIconCssClass();


### PR DESCRIPTION
Hey Máté,

here is the first sub-task.

I checked Dani's hint about using the PersistedModelLocalServiceRegistryUtil instead of modifying the AssetRenderers directly.
See https://github.com/moltam89/liferay-portal/commit/e7b6372b122f10e02b8083872db8f481d5397552.

I found it quite easy to use, but it won't work in all cases. 
E.g. the **JournalArticleAssetRenderer.getClassPK()** call will return the article's **ResourcePrimKey** not the **PrimaryKey**, therefore I cannot get the JournalArticle.

Even if I could find a way to solve this problem, I cannot see the benefits.
It looks unnatural to me that the *AssetRenderers cannot give back the current entry, that's why I kept the AssetRenderer related changes.

I considered changing the return typr from Object to BaseModel as well, but e.g. FileEntry doesn't implement it. 
Actually, it seems logical to me to keep the freedom of the AssetRenderers.