### PR TITLE
Tests LPS-56374 Document version deletion isn't published

### DIFF
--- a/portal-impl/src/com/liferay/portlet/exportimport/service/impl/StagingLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/exportimport/service/impl/StagingLocalServiceImpl.java
@@ -408,6 +408,7 @@ public class StagingLocalServiceImpl extends StagingLocalServiceBaseImpl {
 
 		try {
 			ExportImportThreadLocal.setLayoutImportInProcess(true);
+			ExportImportThreadLocal.setLayoutStagingInProcess(true);
 
 			Folder folder = PortletFileRepositoryUtil.getPortletFolder(
 				stagingRequestId);
@@ -441,6 +442,7 @@ public class StagingLocalServiceImpl extends StagingLocalServiceBaseImpl {
 		}
 		finally {
 			ExportImportThreadLocal.setLayoutImportInProcess(false);
+			ExportImportThreadLocal.setLayoutStagingInProcess(false);
 		}
 	}
 


### PR DESCRIPTION
Hey Máté,

Brian asked me on the previous [pr](https://github.com/brianchandotcom/liferay-portal/pull/27346)  to create tests .

Furthermore, I noticed that the fix was not complete, because in case of remote staging the staging life cycle was not set properly.

**LayoutRemoteStagingBackgroundTaskExecutor** sets it to true, however it affects only the export process, while the fix modifies the import process.

Thanks,
Tamás
