### PR TITLE
LPS-57388 Import using 'Copy as new' fails for Wiki Page

### DIFF
--- a/modules/apps/wiki/wiki-service/src/com/liferay/wiki/lar/WikiPageStagedModelDataHandler.java
+++ b/modules/apps/wiki/wiki-service/src/com/liferay/wiki/lar/WikiPageStagedModelDataHandler.java
@@ -176,7 +176,9 @@ public class WikiPageStagedModelDataHandler
 		ServiceContext serviceContext = portletDataContext.createServiceContext(
 			page);
 
-		serviceContext.setUuid(page.getUuid());
+		if (portletDataContext.isDataStrategyMirror()) {
+			serviceContext.setUuid(page.getUuid());
+		}
 
 		Map<Long, Long> nodeIds =
 			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
@@ -197,19 +199,21 @@ public class WikiPageStagedModelDataHandler
 				page.getFormat(), page.getHead(), page.getParentTitle(),
 				page.getRedirectTitle(), serviceContext);
 
-			WikiPageResource pageResource =
-				WikiPageResourceLocalServiceUtil.getPageResource(
-					importedPage.getResourcePrimKey());
+			if (portletDataContext.isDataStrategyMirror()) {
+				WikiPageResource pageResource =
+					WikiPageResourceLocalServiceUtil.getPageResource(
+						importedPage.getResourcePrimKey());
 
-			String pageResourceUuid = GetterUtil.getString(
-				pageElement.attributeValue("page-resource-uuid"));
-
-			if (Validator.isNotNull(pageResourceUuid)) {
-				pageResource.setUuid(
+				String pageResourceUuid = GetterUtil.getString(
 					pageElement.attributeValue("page-resource-uuid"));
 
-				WikiPageResourceLocalServiceUtil.updateWikiPageResource(
-					pageResource);
+				if (Validator.isNotNull(pageResourceUuid)) {
+					pageResource.setUuid(
+						pageElement.attributeValue("page-resource-uuid"));
+
+					WikiPageResourceLocalServiceUtil.updateWikiPageResource(
+						pageResource);
+				}
 			}
 		}
 		else {


### PR DESCRIPTION
Hello Máté,

I realized, for Wiki the copy as new is only used at node level, so I only changed the parts which caused constraint violations when using copy as new.

Regards,
Zsolt