### PR TITLE
[TECHNICAL-SUPPORT] LPS-59580 Page settings are lost if page versioning / staging was disabled before initial publish

### DIFF
--- a/portal-impl/src/com/liferay/portlet/exportimport/service/impl/StagingLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/exportimport/service/impl/StagingLocalServiceImpl.java
@@ -577,7 +577,7 @@ public class StagingLocalServiceImpl extends StagingLocalServiceBaseImpl {
 	protected void deleteLayoutSetBranches(long groupId, boolean privateLayout)
 		throws PortalException {
 
-		// Find the latest layout revision for all the published layouts
+		// Find the latest layout revision for all the layouts
 
 		Map<Long, LayoutRevision> layoutRevisions = new HashMap<>();
 
@@ -640,7 +640,7 @@ public class StagingLocalServiceImpl extends StagingLocalServiceBaseImpl {
 			}
 		}
 
-		// Update all layouts based on their latest published revision
+		// Update all layouts based on their latest revision
 
 		for (LayoutRevision layoutRevision : layoutRevisions.values()) {
 			updateLayoutWithLayoutRevision(layoutRevision);

--- a/portal-impl/src/com/liferay/portlet/exportimport/service/impl/StagingLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/exportimport/service/impl/StagingLocalServiceImpl.java
@@ -585,16 +585,33 @@ public class StagingLocalServiceImpl extends StagingLocalServiceBaseImpl {
 			layoutSetBranchLocalService.getLayoutSetBranches(
 				groupId, privateLayout);
 
+		boolean publishedToLive = false;
+
 		for (LayoutSetBranch layoutSetBranch : layoutSetBranches) {
 			String lastPublishDateString = layoutSetBranch.getSettingsProperty(
 				"last-publish-date");
 
-			if (Validator.isNull(lastPublishDateString)) {
+			if (Validator.isNotNull(lastPublishDateString)) {
+				publishedToLive = true;
+
+				break;
+			}
+		}
+
+		for (LayoutSetBranch layoutSetBranch : layoutSetBranches) {
+			String lastPublishDateString = layoutSetBranch.getSettingsProperty(
+				"last-publish-date");
+
+			if (Validator.isNull(lastPublishDateString) && publishedToLive) {
 				continue;
 			}
 
-			Date lastPublishDate = new Date(
-				GetterUtil.getLong(lastPublishDateString));
+			Date lastPublishDate = null;
+
+			if (Validator.isNotNull(lastPublishDateString)) {
+				lastPublishDate = new Date(
+					GetterUtil.getLong(lastPublishDateString));
+			}
 
 			List<LayoutRevision> headLayoutRevisions =
 				layoutRevisionLocalService.getLayoutRevisions(
@@ -614,7 +631,8 @@ public class StagingLocalServiceImpl extends StagingLocalServiceBaseImpl {
 				Date statusDate = headLayoutRevision.getStatusDate();
 
 				if (statusDate.after(layoutRevision.getStatusDate()) &&
-					lastPublishDate.after(statusDate)) {
+					((lastPublishDate == null) ||
+					 lastPublishDate.after(statusDate))) {
 
 					layoutRevisions.put(
 						headLayoutRevision.getPlid(), headLayoutRevision);


### PR DESCRIPTION
Hi Máté,

it's a small fix to restore the latest revision's data even if there was no publish before we turned off page versioning / staging.

Thanks,
Tamás