### PR TITLE
[TECHNICAL-SUPPORT] LPS-60791 Deleted Role recreated if it had permissions on a portlet added to a Site Template's page

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/lar/PermissionImporter.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/lar/PermissionImporter.java
@@ -36,6 +36,7 @@ import com.liferay.portal.service.TeamLocalServiceUtil;
 import com.liferay.portal.service.permission.PortletPermissionUtil;
 import com.liferay.portlet.exportimport.lar.ExportImportPathUtil;
 import com.liferay.portlet.exportimport.lar.PortletDataContext;
+import com.liferay.portlet.exportimport.staging.MergeLayoutPrototypesThreadLocal;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -180,7 +181,7 @@ public class PermissionImporter {
 			role = layoutCache.getNameRole(companyId, name);
 		}
 
-		if (role != null) {
+		if ((role != null) || MergeLayoutPrototypesThreadLocal.isInProgress()) {
 			return role;
 		}
 
@@ -233,6 +234,10 @@ public class PermissionImporter {
 		for (Element roleElement : roleElements) {
 			Role role = checkRole(
 				layoutCache, companyId, groupId, userId, roleElement);
+
+			if (role == null) {
+				continue;
+			}
 
 			Group group = GroupLocalServiceUtil.getGroup(groupId);
 


### PR DESCRIPTION
Hey Máté,

As the portal stores cached versions from the Site Templates, in some circumstances the deleted roles are reborn from it.

I think there is no need for creating new roles while the Site Template's content is imported, as the roles should be already there.

Actually, exporting the roles seems unnecessary as well, but the permissions are related tightly to the roles, so it is not that easy to separate them and export the permissions without the roles.

Could you please review my changes?

Thanks,
Tamás