### PR TITLE
LPS-61794 PermissionChecker for Staging

### DIFF
--- a/modules/apps/staging/staging-security/bnd.bnd
+++ b/modules/apps/staging/staging-security/bnd.bnd
@@ -1,0 +1,7 @@
+Bundle-Name: Liferay Staging Security
+Bundle-SymbolicName: com.liferay.staging.security
+Bundle-Version: 1.0.0
+Include-Resource: classes
+Liferay-Releng-Module-Group-Description:
+Liferay-Releng-Module-Group-Title: Data Management
+-include: ../../../../marketplace/web-content-management/bnd.bnd

--- a/modules/apps/staging/staging-security/build.gradle
+++ b/modules/apps/staging/staging-security/build.gradle
@@ -1,0 +1,3 @@
+liferay {
+	deployDir = file("${liferayHome}/osgi/modules")
+}

--- a/modules/apps/staging/staging-security/build.gradle
+++ b/modules/apps/staging/staging-security/build.gradle
@@ -1,3 +1,9 @@
+dependencies {
+	compile group: "com.liferay.portal", name: "portal-service", version: liferay.portalVersion
+	compile group: "javax.portlet", name: "portlet-api", version: "2.0"
+	compile group: "org.osgi", name: "org.osgi.compendium", version: "5.0.0"
+}
+
 liferay {
 	deployDir = file("${liferayHome}/osgi/modules")
 }

--- a/modules/apps/staging/staging-security/build.gradle
+++ b/modules/apps/staging/staging-security/build.gradle
@@ -2,6 +2,7 @@ dependencies {
 	compile group: "com.liferay.portal", name: "portal-service", version: liferay.portalVersion
 	compile group: "javax.portlet", name: "portlet-api", version: "2.0"
 	compile group: "org.osgi", name: "org.osgi.compendium", version: "5.0.0"
+	compile group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
 }
 
 liferay {

--- a/modules/apps/staging/staging-security/build.xml
+++ b/modules/apps/staging/staging-security/build.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<!DOCTYPE project>
+
+<project>
+	<import file="../../../build-module.xml" />
+</project>

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/permission/StagingPermissionChecker.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/permission/StagingPermissionChecker.java
@@ -1,0 +1,215 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.staging.security.permission;
+
+import com.liferay.portal.model.User;
+import com.liferay.portal.security.permission.PermissionChecker;
+import com.liferay.portal.security.permission.UserBag;
+
+import java.util.List;
+
+import javax.portlet.PortletRequest;
+
+/**
+ * @author Tomas Polesovsky
+ */
+public class StagingPermissionChecker implements PermissionChecker {
+
+	public StagingPermissionChecker(PermissionChecker permissionChecker) {
+		_permissionChecker = permissionChecker;
+	}
+
+	@Override
+	public PermissionChecker clone() {
+		return new StagingPermissionChecker(_permissionChecker.clone());
+	}
+
+	@Override
+	public long getCompanyId() {
+		return _permissionChecker.getCompanyId();
+	}
+
+	@Override
+	public List<Long> getOwnerResourceBlockIds(
+		long companyId, long groupId, String name, String actionId) {
+
+		return _permissionChecker.getOwnerResourceBlockIds(
+			companyId, groupId, name, actionId);
+	}
+
+	@Override
+	public long getOwnerRoleId() {
+		return _permissionChecker.getOwnerRoleId();
+	}
+
+	@Override
+	public List<Long> getResourceBlockIds(
+		long companyId, long groupId, long userId, String name,
+		String actionId) {
+
+		return _permissionChecker.getResourceBlockIds(
+			companyId, groupId, userId, name, actionId);
+	}
+
+	@Override
+	public long[] getRoleIds(long userId, long groupId) {
+		return _permissionChecker.getRoleIds(userId, groupId);
+	}
+
+	@Override
+	public User getUser() {
+		return _permissionChecker.getUser();
+	}
+
+	@Override
+	public UserBag getUserBag() throws Exception {
+		return _permissionChecker.getUserBag();
+	}
+
+	@Override
+	public long getUserId() {
+		return _permissionChecker.getUserId();
+	}
+
+	@Override
+	public boolean hasOwnerPermission(
+		long companyId, String name, long primKey, long ownerId,
+		String actionId) {
+
+		return _permissionChecker.hasOwnerPermission(
+			companyId, name, primKey, ownerId, actionId);
+	}
+
+	@Override
+	public boolean hasOwnerPermission(
+		long companyId, String name, String primKey, long ownerId,
+		String actionId) {
+
+		return _permissionChecker.hasOwnerPermission(
+			companyId, name, primKey, ownerId, actionId);
+	}
+
+	@Override
+	public boolean hasPermission(
+		long groupId, String name, long primKey, String actionId) {
+
+		return _permissionChecker.hasPermission(
+			groupId, name, primKey, actionId);
+	}
+
+	@Override
+	public boolean hasPermission(
+		long groupId, String name, String primKey, String actionId) {
+
+		return _permissionChecker.hasPermission(
+			groupId, name, primKey, actionId);
+	}
+
+	@Override
+	public boolean hasUserPermission(
+		long groupId, String name, String primKey, String actionId,
+		boolean checkAdmin) {
+
+		return _permissionChecker.hasUserPermission(
+			groupId, name, primKey, actionId, checkAdmin);
+	}
+
+	@Override
+	public void init(User user) {
+		_permissionChecker.init(user);
+	}
+
+	@Override
+	public boolean isCheckGuest() {
+		return _permissionChecker.isCheckGuest();
+	}
+
+	@Deprecated
+	@Override
+	public boolean isCommunityAdmin(long groupId) {
+		return _permissionChecker.isCommunityAdmin(groupId);
+	}
+
+	@Deprecated
+	@Override
+	public boolean isCommunityOwner(long groupId) {
+		return _permissionChecker.isCommunityOwner(groupId);
+	}
+
+	@Override
+	public boolean isCompanyAdmin() {
+		return _permissionChecker.isCompanyAdmin();
+	}
+
+	@Override
+	public boolean isCompanyAdmin(long companyId) {
+		return _permissionChecker.isCompanyAdmin(companyId);
+	}
+
+	@Override
+	public boolean isContentReviewer(long companyId, long groupId) {
+		return _permissionChecker.isContentReviewer(companyId, groupId);
+	}
+
+	@Override
+	public boolean isGroupAdmin(long groupId) {
+		return _permissionChecker.isGroupAdmin(groupId);
+	}
+
+	@Override
+	public boolean isGroupMember(long groupId) {
+		return _permissionChecker.isGroupMember(groupId);
+	}
+
+	@Override
+	public boolean isGroupOwner(long groupId) {
+		return _permissionChecker.isGroupOwner(groupId);
+	}
+
+	@Override
+	public boolean isOmniadmin() {
+		return _permissionChecker.isOmniadmin();
+	}
+
+	@Override
+	public boolean isOrganizationAdmin(long organizationId) {
+		return _permissionChecker.isOrganizationAdmin(organizationId);
+	}
+
+	@Override
+	public boolean isOrganizationOwner(long organizationId) {
+		return _permissionChecker.isOrganizationOwner(organizationId);
+	}
+
+	@Override
+	public boolean isSignedIn() {
+		return _permissionChecker.isSignedIn();
+	}
+
+	@Deprecated
+	@Override
+	public void resetValues() {
+		_permissionChecker.resetValues();
+	}
+
+	@Deprecated
+	@Override
+	public void setValues(PortletRequest portletRequest) {
+		_permissionChecker.setValues(portletRequest);
+	}
+
+	private final PermissionChecker _permissionChecker;
+
+}

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/permission/StagingPermissionChecker.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/permission/StagingPermissionChecker.java
@@ -114,6 +114,12 @@ public class StagingPermissionChecker implements PermissionChecker {
 
 		long liveGroupId = StagingUtil.getLiveGroupId(groupId);
 
+		if (liveGroupId != groupId) {
+			if (primKey == groupId) {
+				primKey = liveGroupId;
+			}
+		}
+
 		return _permissionChecker.hasPermission(
 			liveGroupId, name, primKey, actionId);
 	}
@@ -123,6 +129,12 @@ public class StagingPermissionChecker implements PermissionChecker {
 		long groupId, String name, String primKey, String actionId) {
 
 		long liveGroupId = StagingUtil.getLiveGroupId(groupId);
+
+		if (liveGroupId != groupId) {
+			if (primKey.equals(String.valueOf(groupId))) {
+				primKey = String.valueOf(liveGroupId);
+			}
+		}
 
 		return _permissionChecker.hasPermission(
 			liveGroupId, name, primKey, actionId);

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/permission/StagingPermissionChecker.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/permission/StagingPermissionChecker.java
@@ -17,6 +17,7 @@ package com.liferay.staging.security.permission;
 import com.liferay.portal.model.User;
 import com.liferay.portal.security.permission.PermissionChecker;
 import com.liferay.portal.security.permission.UserBag;
+import com.liferay.portlet.exportimport.staging.StagingUtil;
 
 import java.util.List;
 
@@ -45,8 +46,10 @@ public class StagingPermissionChecker implements PermissionChecker {
 	public List<Long> getOwnerResourceBlockIds(
 		long companyId, long groupId, String name, String actionId) {
 
+		long liveGroupId = StagingUtil.getLiveGroupId(groupId);
+
 		return _permissionChecker.getOwnerResourceBlockIds(
-			companyId, groupId, name, actionId);
+			companyId, liveGroupId, name, actionId);
 	}
 
 	@Override
@@ -59,13 +62,17 @@ public class StagingPermissionChecker implements PermissionChecker {
 		long companyId, long groupId, long userId, String name,
 		String actionId) {
 
+		long liveGroupId = StagingUtil.getLiveGroupId(groupId);
+
 		return _permissionChecker.getResourceBlockIds(
-			companyId, groupId, userId, name, actionId);
+			companyId, liveGroupId, userId, name, actionId);
 	}
 
 	@Override
 	public long[] getRoleIds(long userId, long groupId) {
-		return _permissionChecker.getRoleIds(userId, groupId);
+		long liveGroupId = StagingUtil.getLiveGroupId(groupId);
+
+		return _permissionChecker.getRoleIds(userId, liveGroupId);
 	}
 
 	@Override
@@ -105,16 +112,20 @@ public class StagingPermissionChecker implements PermissionChecker {
 	public boolean hasPermission(
 		long groupId, String name, long primKey, String actionId) {
 
+		long liveGroupId = StagingUtil.getLiveGroupId(groupId);
+
 		return _permissionChecker.hasPermission(
-			groupId, name, primKey, actionId);
+			liveGroupId, name, primKey, actionId);
 	}
 
 	@Override
 	public boolean hasPermission(
 		long groupId, String name, String primKey, String actionId) {
 
+		long liveGroupId = StagingUtil.getLiveGroupId(groupId);
+
 		return _permissionChecker.hasPermission(
-			groupId, name, primKey, actionId);
+			liveGroupId, name, primKey, actionId);
 	}
 
 	@Override
@@ -122,8 +133,10 @@ public class StagingPermissionChecker implements PermissionChecker {
 		long groupId, String name, String primKey, String actionId,
 		boolean checkAdmin) {
 
+		long liveGroupId = StagingUtil.getLiveGroupId(groupId);
+
 		return _permissionChecker.hasUserPermission(
-			groupId, name, primKey, actionId, checkAdmin);
+			liveGroupId, name, primKey, actionId, checkAdmin);
 	}
 
 	@Override
@@ -139,13 +152,17 @@ public class StagingPermissionChecker implements PermissionChecker {
 	@Deprecated
 	@Override
 	public boolean isCommunityAdmin(long groupId) {
-		return _permissionChecker.isCommunityAdmin(groupId);
+		long liveGroupId = StagingUtil.getLiveGroupId(groupId);
+
+		return _permissionChecker.isCommunityAdmin(liveGroupId);
 	}
 
 	@Deprecated
 	@Override
 	public boolean isCommunityOwner(long groupId) {
-		return _permissionChecker.isCommunityOwner(groupId);
+		long liveGroupId = StagingUtil.getLiveGroupId(groupId);
+
+		return _permissionChecker.isCommunityOwner(liveGroupId);
 	}
 
 	@Override
@@ -160,22 +177,30 @@ public class StagingPermissionChecker implements PermissionChecker {
 
 	@Override
 	public boolean isContentReviewer(long companyId, long groupId) {
-		return _permissionChecker.isContentReviewer(companyId, groupId);
+		long liveGroupId = StagingUtil.getLiveGroupId(groupId);
+
+		return _permissionChecker.isContentReviewer(companyId, liveGroupId);
 	}
 
 	@Override
 	public boolean isGroupAdmin(long groupId) {
-		return _permissionChecker.isGroupAdmin(groupId);
+		long liveGroupId = StagingUtil.getLiveGroupId(groupId);
+
+		return _permissionChecker.isGroupAdmin(liveGroupId);
 	}
 
 	@Override
 	public boolean isGroupMember(long groupId) {
-		return _permissionChecker.isGroupMember(groupId);
+		long liveGroupId = StagingUtil.getLiveGroupId(groupId);
+
+		return _permissionChecker.isGroupMember(liveGroupId);
 	}
 
 	@Override
 	public boolean isGroupOwner(long groupId) {
-		return _permissionChecker.isGroupOwner(groupId);
+		long liveGroupId = StagingUtil.getLiveGroupId(groupId);
+
+		return _permissionChecker.isGroupOwner(liveGroupId);
 	}
 
 	@Override

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/permission/StagingPermissionCheckerFactory.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/permission/StagingPermissionCheckerFactory.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.staging.security.permission;
+
+import com.liferay.portal.model.User;
+import com.liferay.portal.security.permission.PermissionChecker;
+import com.liferay.portal.security.permission.PermissionCheckerFactory;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Tomas Polesovsky
+ */
+@Component(immediate = true)
+public class StagingPermissionCheckerFactory
+	implements PermissionCheckerFactory {
+
+	@Override
+	public PermissionChecker create(User user) throws Exception {
+		return new StagingPermissionChecker(null);
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
@@ -372,17 +372,6 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 
 					groupId = group.getGroupId();
 				}
-
-				// If the group is a staging group, check the live group.
-
-				if (group.isStagingGroup()) {
-					if (primKey.equals(String.valueOf(groupId))) {
-						primKey = String.valueOf(group.getLiveGroupId());
-					}
-
-					groupId = group.getLiveGroupId();
-					group = group.getLiveGroup();
-				}
 			}
 		}
 		catch (Exception e) {


### PR DESCRIPTION
Hi Mate,

it's a first part of https://github.com/topolik/liferay-portal/pull/228

Here I made sure the groupId coming into PermissionChecker is always from live group.

Sometimes code in portal use staging groupId, sometimes live groupId, but site membership and site/org roles are preserved on the original-live group.

I believe it's better to fix here then to fix those places in portal and check it each month again :)

Thanks.