### PR TITLE
LPS-61795 User, Site, UserGroup and Organization membership to Roles should not use staging groupId

### DIFF
--- a/modules/apps/staging/staging-security/build.gradle
+++ b/modules/apps/staging/staging-security/build.gradle
@@ -1,8 +1,10 @@
 dependencies {
+	compile group: "com.liferay.portal", name: "portal-impl", version: liferay.portalVersion
 	compile group: "com.liferay.portal", name: "portal-service", version: liferay.portalVersion
 	compile group: "javax.portlet", name: "portlet-api", version: "2.0"
 	compile group: "org.osgi", name: "org.osgi.compendium", version: "5.0.0"
 	compile group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
+	compile group: "org.springframework", name: "spring-aop", version: "3.2.15.RELEASE"
 }
 
 liferay {

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/permission/StagingPermissionCheckerFactory.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/permission/StagingPermissionCheckerFactory.java
@@ -17,6 +17,7 @@ package com.liferay.staging.security.permission;
 import com.liferay.portal.model.User;
 import com.liferay.portal.security.permission.PermissionChecker;
 import com.liferay.portal.security.permission.PermissionCheckerFactory;
+import com.liferay.portlet.exportimport.staging.Staging;
 
 import java.util.Collection;
 import java.util.Iterator;
@@ -25,6 +26,7 @@ import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Tomas Polesovsky
@@ -68,6 +70,10 @@ public class StagingPermissionCheckerFactory
 	@Activate
 	protected void activate(BundleContext bundleContext) {
 		_bundleContext = bundleContext;
+	}
+
+	@Reference(unbind = "-")
+	protected void setStaging(Staging staging) {
 	}
 
 	private BundleContext _bundleContext;

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/GroupLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/GroupLocalServiceStagingAdvice.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.staging.security.spring;
+
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.service.GroupLocalService;
+
+import java.lang.reflect.Method;
+
+/**
+ * @author Tomas Polesovsky
+ */
+public class GroupLocalServiceStagingAdvice extends LiveGroupStagingAdvice {
+
+	public GroupLocalServiceStagingAdvice() throws NoSuchMethodException {
+		super(GroupLocalService.class);
+
+		initRelatedServiceBuilderMethods("Organization");
+		initRelatedServiceBuilderMethods("Role");
+		initRelatedServiceBuilderMethods("User");
+		initRelatedServiceBuilderMethods("UserGroup");
+
+		initCustomMethod("getUserGroupPrimaryKeys", 0, long.class);
+	}
+
+	protected void initRelatedServiceBuilderMethods(String relatedEntityName)
+		throws NoSuchMethodException {
+
+		Method[] relatedEntityMethods = GroupLocalService.class.getMethods();
+
+		for (String template : _SERVICE_BUILDER_GENERATED_TEMPLATES) {
+			String serviceBuilderMethodName = StringUtil.replace(
+				template, "$1", relatedEntityName);
+
+			for (Method method : relatedEntityMethods) {
+				if (method.getName().equals(serviceBuilderMethodName)) {
+					initCustomMethod(
+						serviceBuilderMethodName, 1,
+						method.getParameterTypes());
+				}
+			}
+		}
+	}
+
+	private static final String[] _SERVICE_BUILDER_GENERATED_TEMPLATES =
+		new String[] {
+			"add$1Group", "add$1Groups", "delete$1Group", "delete$1Groups",
+			"has$1Group", "set$1Groups", "unset$1Groups"
+		};
+
+}

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/GroupLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/GroupLocalServiceStagingAdvice.java
@@ -19,9 +19,13 @@ import com.liferay.portal.service.GroupLocalService;
 
 import java.lang.reflect.Method;
 
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
 /**
  * @author Tomas Polesovsky
  */
+@Component(immediate = true)
 public class GroupLocalServiceStagingAdvice extends LiveGroupStagingAdvice {
 
 	public GroupLocalServiceStagingAdvice() throws NoSuchMethodException {
@@ -52,6 +56,15 @@ public class GroupLocalServiceStagingAdvice extends LiveGroupStagingAdvice {
 				}
 			}
 		}
+	}
+
+	@Reference
+	protected void setService(GroupLocalService service) {
+		registerAdvice(service);
+	}
+
+	protected void unsetService(GroupLocalService service) {
+		unregisterAdvice(service);
 	}
 
 	private static final String[] _SERVICE_BUILDER_GENERATED_TEMPLATES =

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/GroupLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/GroupLocalServiceStagingAdvice.java
@@ -16,6 +16,7 @@ package com.liferay.staging.security.spring;
 
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.service.GroupLocalService;
+import com.liferay.portlet.exportimport.staging.Staging;
 
 import java.lang.reflect.Method;
 
@@ -61,6 +62,10 @@ public class GroupLocalServiceStagingAdvice extends LiveGroupStagingAdvice {
 	@Reference
 	protected void setService(GroupLocalService service) {
 		registerAdvice(service);
+	}
+
+	@Reference(unbind = "-")
+	protected void setStaging(Staging staging) {
 	}
 
 	protected void unsetService(GroupLocalService service) {

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/LiveGroupStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/LiveGroupStagingAdvice.java
@@ -43,6 +43,37 @@ public abstract class LiveGroupStagingAdvice implements MethodInterceptor {
 		_localServiceClass = localServiceClass;
 	}
 
+	public void checkCoverage(List<String> falsePositivesList) {
+		Method[] methods = _localServiceClass.getMethods();
+
+		for (Method method : methods) {
+			String methodName = method.getName();
+			String methodNameWithoutUserGroup = StringUtil.replace(
+				methodName, "UserGroup", "");
+
+			if (methodNameWithoutUserGroup.contains("Group")) {
+				if (_serviceBuilderGeneratedMethods.contains(method)) {
+					continue;
+				}
+
+				if (_customMethods.containsKey(method)) {
+					continue;
+				}
+
+				if (falsePositivesList.contains(methodName)) {
+					continue;
+				}
+
+				_log.error(
+					"Please update " + getClass().getName() + " with " +
+					method + ". The method must be processed when it " +
+					"contains groupId, otherwise it's safe to add the method " +
+					"name to " + getClass().getSimpleName() +
+					"._GROUP_METHODS_WHITELIST");
+			}
+		}
+	}
+
 	public void initCustomMethod(
 			String methodName, Integer index, Class... parameterTypes)
 		throws NoSuchMethodException {

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/LiveGroupStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/LiveGroupStagingAdvice.java
@@ -1,0 +1,256 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.staging.security.spring;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.model.Group;
+import com.liferay.portlet.exportimport.staging.StagingAdvicesThreadLocal;
+import com.liferay.portlet.exportimport.staging.StagingUtil;
+
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+
+/**
+ * @author Tomas Polesovsky
+ */
+public abstract class LiveGroupStagingAdvice implements MethodInterceptor {
+
+	public LiveGroupStagingAdvice(Class localServiceClass) {
+		_localServiceClass = localServiceClass;
+	}
+
+	public void initCustomMethod(
+			String methodName, Integer index, Class... parameterTypes)
+		throws NoSuchMethodException {
+
+		Method customMethod = _localServiceClass.getMethod(
+			methodName, parameterTypes);
+
+		if (_log.isDebugEnabled()) {
+			_log.debug("Registering " + customMethod);
+		}
+
+		_customMethods.put(customMethod, new Integer[] {index});
+	}
+
+	public void initGroupServiceBuilderMethods() {
+		String className = _localServiceClass.getSimpleName();
+		String relatedEntityName = className.substring(
+			0, className.length() - _LOCAL_SERVICE.length());
+
+		Method[] relatedEntityMethods = _localServiceClass.getMethods();
+
+		for (String template : _SERVICE_BUILDER_GENERATED_GROUP_TEMPLATES) {
+			String serviceBuilderMethodName = StringUtil.replace(
+				template, "$1", relatedEntityName);
+
+			for (Method method : relatedEntityMethods) {
+				if (method.getName().equals(serviceBuilderMethodName)) {
+					_serviceBuilderGeneratedMethods.add(method);
+
+					if (_log.isDebugEnabled()) {
+						_log.debug("Registering " + method);
+					}
+				}
+			}
+		}
+	}
+
+	@Override
+	public Object invoke(MethodInvocation methodInvocation) throws Throwable {
+		if (!StagingAdvicesThreadLocal.isEnabled()) {
+			return methodInvocation.proceed();
+		}
+
+		replaceStagingGroupIdsInServiceBuilderGeneratedMethod(methodInvocation);
+
+		replaceStagingGroupIdsInCustomMethod(methodInvocation);
+
+		return methodInvocation.proceed();
+	}
+
+	protected Group replace(Group group) {
+		if (group == null) {
+			return group;
+		}
+
+		return StagingUtil.getLiveGroup(group.getGroupId());
+	}
+
+	protected long replace(long groupId) {
+		if (groupId == 0) {
+			return groupId;
+		}
+
+		return StagingUtil.getLiveGroupId(groupId);
+	}
+
+	protected void replace(Object[] arguments, int index) {
+		if (arguments == null) {
+			return;
+		}
+
+		Object object = arguments[index];
+
+		if (object == null) {
+			return;
+		}
+
+		if (object instanceof Long) {
+			long groupId = (Long)object;
+
+			arguments[index] = replace(groupId);
+
+			return;
+		}
+
+		if (object instanceof Group) {
+			Group group = (Group)object;
+
+			arguments[index] = replace(group);
+
+			return;
+		}
+
+		if (object instanceof long[]) {
+			long[] groupIds = (long[])object;
+
+			for (int i = 0; i < groupIds.length; i++) {
+				groupIds[i] = replace(groupIds[i]);
+			}
+
+			return;
+		}
+
+		if (object instanceof Long[]) {
+			Long[] groupIds = (Long[])object;
+
+			for (int i = 0; i < groupIds.length; i++) {
+				groupIds[i] = replace(groupIds[i]);
+			}
+
+			return;
+		}
+
+		if (object instanceof Group[]) {
+			Group[] groups = (Group[])object;
+
+			for (int i = 0; i < groups.length; i++) {
+				groups[i] = replace(groups[i]);
+			}
+
+			return;
+		}
+
+		if (object instanceof Collection) {
+			Collection collection = (Collection)object;
+
+			if (collection.size() == 0) {
+				return;
+			}
+
+			Object[] collectionArray = collection.toArray(
+				new Object[collection.size()]);
+
+			for (int i = 0; i < collectionArray.length; i++) {
+				replace(collectionArray, i);
+			}
+
+			if (object instanceof List) {
+				arguments[index] = new ArrayList();
+			}
+			else if (object instanceof Set) {
+				arguments[index] = new LinkedHashSet<>();
+			}
+			else {
+				throw new UnsupportedOperationException(
+					"Unknown collection type " + object.getClass());
+			}
+
+			Collection newCollection = (Collection)arguments[index];
+
+			for (Object group : collectionArray) {
+				newCollection.add(group);
+			}
+
+			return;
+		}
+
+		throw new UnsupportedOperationException(
+			"Unknown type " + object.getClass());
+	}
+
+	protected void replaceStagingGroupIdsInCustomMethod(
+		MethodInvocation methodInvocation) {
+
+		Method method = methodInvocation.getMethod();
+
+		Integer[] argumentIndexes = _customMethods.get(method);
+
+		if (argumentIndexes == null) {
+			return;
+		}
+
+		Object[] arguments = methodInvocation.getArguments();
+
+		for (Integer argumentIndex : argumentIndexes) {
+			replace(arguments, argumentIndex);
+		}
+	}
+
+	protected void replaceStagingGroupIdsInServiceBuilderGeneratedMethod(
+		MethodInvocation methodInvocation) {
+
+		Method method = methodInvocation.getMethod();
+
+		if (!_serviceBuilderGeneratedMethods.contains(method)) {
+			return;
+		}
+
+		Object[] arguments = methodInvocation.getArguments();
+
+		replace(arguments, 0);
+	}
+
+	private static final String _LOCAL_SERVICE = "LocalService";
+
+	private static final String[] _SERVICE_BUILDER_GENERATED_GROUP_TEMPLATES =
+		new String[] {
+			"addGroup$1", "addGroup$1s", "clearGroup$1s", "deleteGroup$1",
+			"deleteGroup$1s", "getGroup$1s", "getGroup$1sCount", "hasGroup$1",
+			"hasGroup$1s", "setGroup$1s", "unsetGroup$1s"
+		};
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		LiveGroupStagingAdvice.class);
+
+	private final Map<Method, Integer[]> _customMethods = new HashMap<>();
+	private final Class _localServiceClass;
+	private final List<Method> _serviceBuilderGeneratedMethods =
+		new ArrayList<>();
+
+}

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/LiveGroupStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/LiveGroupStagingAdvice.java
@@ -16,8 +16,11 @@ package com.liferay.staging.security.spring;
 
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.ProxyUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.model.Group;
+import com.liferay.portal.spring.aop.ServiceBeanAopCacheManagerUtil;
+import com.liferay.portal.spring.aop.ServiceBeanAopProxy;
 import com.liferay.portlet.exportimport.staging.StagingAdvicesThreadLocal;
 import com.liferay.portlet.exportimport.staging.StagingUtil;
 
@@ -33,6 +36,8 @@ import java.util.Set;
 
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
+
+import org.springframework.aop.framework.AdvisedSupport;
 
 /**
  * @author Tomas Polesovsky
@@ -122,6 +127,33 @@ public abstract class LiveGroupStagingAdvice implements MethodInterceptor {
 		replaceStagingGroupIdsInCustomMethod(methodInvocation);
 
 		return methodInvocation.proceed();
+	}
+
+	protected void registerAdvice(Object service) {
+		try {
+			Class<?> clazz = service.getClass();
+
+			if (!ProxyUtil.isProxyClass(clazz)) {
+				throw new RuntimeException(
+					"Unable to register advice " + getClass().getName() +
+						" for " + _localServiceClass.getName() +
+						", Spring bean " + clazz.getName() +
+						" is not proxy");
+			}
+
+			AdvisedSupport advisedSupport =
+				ServiceBeanAopProxy.getAdvisedSupport(service);
+
+			advisedSupport.addAdvice(this);
+
+			ServiceBeanAopCacheManagerUtil.reset();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(
+				"Unable to register advice for " +
+					_localServiceClass.getName(),
+				e);
+		}
 	}
 
 	protected Group replace(Group group) {
@@ -265,6 +297,29 @@ public abstract class LiveGroupStagingAdvice implements MethodInterceptor {
 		Object[] arguments = methodInvocation.getArguments();
 
 		replace(arguments, 0);
+	}
+
+	protected void unregisterAdvice(Object service) {
+		Class<?> clazz = service.getClass();
+
+		if (!ProxyUtil.isProxyClass(clazz)) {
+			return;
+		}
+
+		try {
+			AdvisedSupport advisedSupport =
+				ServiceBeanAopProxy.getAdvisedSupport(service);
+
+			advisedSupport.removeAdvice(this);
+
+			ServiceBeanAopCacheManagerUtil.reset();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(
+				"Unable to register advice " + getClass().getName() +
+					" for " + _localServiceClass.getName(),
+				e);
+		}
 	}
 
 	private static final String _LOCAL_SERVICE = "LocalService";

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/OrganizationLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/OrganizationLocalServiceStagingAdvice.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.staging.security.spring;
+
+import com.liferay.portal.service.OrganizationLocalService;
+
+/**
+ * @author Tomas Polesovsky
+ */
+public class OrganizationLocalServiceStagingAdvice
+	extends LiveGroupStagingAdvice {
+
+	public OrganizationLocalServiceStagingAdvice()
+		throws NoSuchMethodException {
+
+		super(OrganizationLocalService.class);
+
+		initGroupServiceBuilderMethods();
+
+		initCustomMethod(
+			"getGroupUserOrganizations", 0, long.class, long.class);
+	}
+
+}

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/OrganizationLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/OrganizationLocalServiceStagingAdvice.java
@@ -16,6 +16,9 @@ package com.liferay.staging.security.spring;
 
 import com.liferay.portal.service.OrganizationLocalService;
 
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * @author Tomas Polesovsky
  */
@@ -31,6 +34,11 @@ public class OrganizationLocalServiceStagingAdvice
 
 		initCustomMethod(
 			"getGroupUserOrganizations", 0, long.class, long.class);
+
+		checkCoverage(_GROUP_METHODS_WHITELIST);
 	}
+
+	private static final List<String> _GROUP_METHODS_WHITELIST = Arrays.asList(
+		new String[] {"getGroupPrimaryKeys"});
 
 }

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/OrganizationLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/OrganizationLocalServiceStagingAdvice.java
@@ -19,9 +19,13 @@ import com.liferay.portal.service.OrganizationLocalService;
 import java.util.Arrays;
 import java.util.List;
 
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
 /**
  * @author Tomas Polesovsky
  */
+@Component(immediate = true)
 public class OrganizationLocalServiceStagingAdvice
 	extends LiveGroupStagingAdvice {
 
@@ -36,6 +40,15 @@ public class OrganizationLocalServiceStagingAdvice
 			"getGroupUserOrganizations", 0, long.class, long.class);
 
 		checkCoverage(_GROUP_METHODS_WHITELIST);
+	}
+
+	@Reference
+	protected void setService(OrganizationLocalService service) {
+		registerAdvice(service);
+	}
+
+	protected void unsetService(OrganizationLocalService service) {
+		unregisterAdvice(service);
 	}
 
 	private static final List<String> _GROUP_METHODS_WHITELIST = Arrays.asList(

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/OrganizationLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/OrganizationLocalServiceStagingAdvice.java
@@ -15,6 +15,7 @@
 package com.liferay.staging.security.spring;
 
 import com.liferay.portal.service.OrganizationLocalService;
+import com.liferay.portlet.exportimport.staging.Staging;
 
 import java.util.Arrays;
 import java.util.List;
@@ -45,6 +46,10 @@ public class OrganizationLocalServiceStagingAdvice
 	@Reference
 	protected void setService(OrganizationLocalService service) {
 		registerAdvice(service);
+	}
+
+	@Reference(unbind = "-")
+	protected void setStaging(Staging staging) {
 	}
 
 	protected void unsetService(OrganizationLocalService service) {

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/RoleLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/RoleLocalServiceStagingAdvice.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.staging.security.spring;
+
+import com.liferay.portal.service.RoleLocalService;
+
+import java.util.List;
+
+/**
+ * @author Tomas Polesovsky
+ */
+public class RoleLocalServiceStagingAdvice extends LiveGroupStagingAdvice {
+
+	public RoleLocalServiceStagingAdvice() throws NoSuchMethodException {
+		super(RoleLocalService.class);
+
+		initGroupServiceBuilderMethods();
+
+		initCustomMethod("getDefaultGroupRole", 0, long.class);
+		initCustomMethod("getGroupRelatedRoles", 0, long.class);
+		initCustomMethod("getTeamRoleMap", 0, long.class);
+		initCustomMethod("getTeamRoles", 0, long.class);
+		initCustomMethod("getTeamRoles", 0, long.class, long[].class);
+		initCustomMethod("getUserGroupGroupRoles", 1, long.class, long.class);
+		initCustomMethod(
+			"getUserGroupGroupRoles", 1, long.class, long.class, int.class,
+			int.class);
+		initCustomMethod(
+			"getUserGroupGroupRolesCount", 1, long.class, long.class);
+		initCustomMethod("getUserGroupRoles", 1, long.class, long.class);
+		initCustomMethod("getUserRelatedRoles", 1, long.class, long.class);
+		initCustomMethod("getUserRelatedRoles", 1, long.class, long[].class);
+		initCustomMethod("getUserRelatedRoles", 1, long.class, List.class);
+	}
+
+}

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/RoleLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/RoleLocalServiceStagingAdvice.java
@@ -16,6 +16,7 @@ package com.liferay.staging.security.spring;
 
 import com.liferay.portal.service.RoleLocalService;
 
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -43,6 +44,11 @@ public class RoleLocalServiceStagingAdvice extends LiveGroupStagingAdvice {
 		initCustomMethod("getUserRelatedRoles", 1, long.class, long.class);
 		initCustomMethod("getUserRelatedRoles", 1, long.class, long[].class);
 		initCustomMethod("getUserRelatedRoles", 1, long.class, List.class);
+
+		checkCoverage(_GROUP_METHODS_WHITELIST);
 	}
+
+	private static final List<String> _GROUP_METHODS_WHITELIST = Arrays.asList(
+		new String[] {"getGroupPrimaryKeys"});
 
 }

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/RoleLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/RoleLocalServiceStagingAdvice.java
@@ -19,9 +19,13 @@ import com.liferay.portal.service.RoleLocalService;
 import java.util.Arrays;
 import java.util.List;
 
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
 /**
  * @author Tomas Polesovsky
  */
+@Component(immediate = true)
 public class RoleLocalServiceStagingAdvice extends LiveGroupStagingAdvice {
 
 	public RoleLocalServiceStagingAdvice() throws NoSuchMethodException {
@@ -46,6 +50,15 @@ public class RoleLocalServiceStagingAdvice extends LiveGroupStagingAdvice {
 		initCustomMethod("getUserRelatedRoles", 1, long.class, List.class);
 
 		checkCoverage(_GROUP_METHODS_WHITELIST);
+	}
+
+	@Reference
+	protected void setService(RoleLocalService service) {
+		registerAdvice(service);
+	}
+
+	protected void unsetService(RoleLocalService service) {
+		unregisterAdvice(service);
 	}
 
 	private static final List<String> _GROUP_METHODS_WHITELIST = Arrays.asList(

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/RoleLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/RoleLocalServiceStagingAdvice.java
@@ -15,6 +15,7 @@
 package com.liferay.staging.security.spring;
 
 import com.liferay.portal.service.RoleLocalService;
+import com.liferay.portlet.exportimport.staging.Staging;
 
 import java.util.Arrays;
 import java.util.List;
@@ -55,6 +56,10 @@ public class RoleLocalServiceStagingAdvice extends LiveGroupStagingAdvice {
 	@Reference
 	protected void setService(RoleLocalService service) {
 		registerAdvice(service);
+	}
+
+	@Reference(unbind = "-")
+	protected void setStaging(Staging staging) {
 	}
 
 	protected void unsetService(RoleLocalService service) {

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupGroupRoleLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupGroupRoleLocalServiceStagingAdvice.java
@@ -16,6 +16,9 @@ package com.liferay.staging.security.spring;
 
 import com.liferay.portal.service.UserGroupGroupRoleLocalService;
 
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * @author Tomas Polesovsky
  */
@@ -61,6 +64,18 @@ public class UserGroupGroupRoleLocalServiceStagingAdvice
 
 		initCustomMethod(
 			"hasUserGroupGroupRole", 1, long.class, long.class, String.class);
+
+		checkCoverage(_GROUP_METHODS_WHITELIST);
 	}
+
+	private static final List<String> _GROUP_METHODS_WHITELIST =
+		Arrays.asList(new String[] {
+			"addUserGroupGroupRole", "createUserGroupGroupRole",
+			"deleteUserGroupGroupRole", "deleteUserGroupGroupRolesByRoleId",
+			"deleteUserGroupGroupRolesByUserGroupId", "fetchUserGroupGroupRole",
+			"getUserGroupGroupRole", "getUserGroupGroupRoles",
+			"getUserGroupGroupRolesByUser", "getUserGroupGroupRolesCount",
+			"updateUserGroupGroupRole"
+		});
 
 }

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupGroupRoleLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupGroupRoleLocalServiceStagingAdvice.java
@@ -19,9 +19,13 @@ import com.liferay.portal.service.UserGroupGroupRoleLocalService;
 import java.util.Arrays;
 import java.util.List;
 
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
 /**
  * @author Tomas Polesovsky
  */
+@Component(immediate = true)
 public class UserGroupGroupRoleLocalServiceStagingAdvice
 	extends LiveGroupStagingAdvice {
 
@@ -66,6 +70,15 @@ public class UserGroupGroupRoleLocalServiceStagingAdvice
 			"hasUserGroupGroupRole", 1, long.class, long.class, String.class);
 
 		checkCoverage(_GROUP_METHODS_WHITELIST);
+	}
+
+	@Reference
+	protected void setService(UserGroupGroupRoleLocalService service) {
+		registerAdvice(service);
+	}
+
+	protected void unsetService(UserGroupGroupRoleLocalService service) {
+		unregisterAdvice(service);
 	}
 
 	private static final List<String> _GROUP_METHODS_WHITELIST =

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupGroupRoleLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupGroupRoleLocalServiceStagingAdvice.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.staging.security.spring;
+
+import com.liferay.portal.service.UserGroupGroupRoleLocalService;
+
+/**
+ * @author Tomas Polesovsky
+ */
+public class UserGroupGroupRoleLocalServiceStagingAdvice
+	extends LiveGroupStagingAdvice {
+
+	public UserGroupGroupRoleLocalServiceStagingAdvice()
+		throws NoSuchMethodException {
+
+		super(UserGroupGroupRoleLocalService.class);
+
+		initCustomMethod(
+			"addUserGroupGroupRoles", 1, long.class, long.class, long[].class);
+
+		initCustomMethod(
+			"addUserGroupGroupRoles", 1, long[].class, long.class, long.class);
+
+		initCustomMethod("deleteUserGroupGroupRoles", 0, long.class, int.class);
+
+		initCustomMethod(
+			"deleteUserGroupGroupRoles", 1, long.class, long.class,
+			long[].class);
+
+		initCustomMethod(
+			"deleteUserGroupGroupRoles", 1, long.class, long[].class);
+
+		initCustomMethod(
+			"deleteUserGroupGroupRoles", 1, long[].class, long.class);
+
+		initCustomMethod(
+			"deleteUserGroupGroupRoles", 1, long[].class, long.class,
+			long.class);
+
+		initCustomMethod("deleteUserGroupGroupRolesByGroupId", 0, long.class);
+
+		initCustomMethod("getUserGroupGroupRoles", 1, long.class, long.class);
+
+		initCustomMethod(
+			"getUserGroupGroupRolesByGroupAndRole", 0, long.class, long.class);
+
+		initCustomMethod(
+			"hasUserGroupGroupRole", 1, long.class, long.class, long.class);
+
+		initCustomMethod(
+			"hasUserGroupGroupRole", 1, long.class, long.class, String.class);
+	}
+
+}

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupGroupRoleLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupGroupRoleLocalServiceStagingAdvice.java
@@ -15,6 +15,7 @@
 package com.liferay.staging.security.spring;
 
 import com.liferay.portal.service.UserGroupGroupRoleLocalService;
+import com.liferay.portlet.exportimport.staging.Staging;
 
 import java.util.Arrays;
 import java.util.List;
@@ -75,6 +76,10 @@ public class UserGroupGroupRoleLocalServiceStagingAdvice
 	@Reference
 	protected void setService(UserGroupGroupRoleLocalService service) {
 		registerAdvice(service);
+	}
+
+	@Reference(unbind = "-")
+	protected void setStaging(Staging staging) {
 	}
 
 	protected void unsetService(UserGroupGroupRoleLocalService service) {

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupLocalServiceStagingAdvice.java
@@ -19,9 +19,13 @@ import com.liferay.portal.service.UserGroupLocalService;
 import java.util.Arrays;
 import java.util.List;
 
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
 /**
  * @author Tomas Polesovsky
  */
+@Component(immediate = true)
 public class UserGroupLocalServiceStagingAdvice extends LiveGroupStagingAdvice {
 
 	public UserGroupLocalServiceStagingAdvice() throws NoSuchMethodException {
@@ -32,6 +36,15 @@ public class UserGroupLocalServiceStagingAdvice extends LiveGroupStagingAdvice {
 		initCustomMethod("getGroupUserUserGroups", 0, long.class, long.class);
 
 		checkCoverage(_GROUP_METHODS_WHITELIST);
+	}
+
+	@Reference
+	protected void setService(UserGroupLocalService service) {
+		registerAdvice(service);
+	}
+
+	protected void unsetService(UserGroupLocalService service) {
+		unregisterAdvice(service);
 	}
 
 	private static final List<String> _GROUP_METHODS_WHITELIST = Arrays.asList(

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupLocalServiceStagingAdvice.java
@@ -16,6 +16,9 @@ package com.liferay.staging.security.spring;
 
 import com.liferay.portal.service.UserGroupLocalService;
 
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * @author Tomas Polesovsky
  */
@@ -27,6 +30,11 @@ public class UserGroupLocalServiceStagingAdvice extends LiveGroupStagingAdvice {
 		initGroupServiceBuilderMethods();
 
 		initCustomMethod("getGroupUserUserGroups", 0, long.class, long.class);
+
+		checkCoverage(_GROUP_METHODS_WHITELIST);
 	}
+
+	private static final List<String> _GROUP_METHODS_WHITELIST = Arrays.asList(
+		new String[] {"getGroupPrimaryKeys"});
 
 }

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupLocalServiceStagingAdvice.java
@@ -15,6 +15,7 @@
 package com.liferay.staging.security.spring;
 
 import com.liferay.portal.service.UserGroupLocalService;
+import com.liferay.portlet.exportimport.staging.Staging;
 
 import java.util.Arrays;
 import java.util.List;
@@ -41,6 +42,10 @@ public class UserGroupLocalServiceStagingAdvice extends LiveGroupStagingAdvice {
 	@Reference
 	protected void setService(UserGroupLocalService service) {
 		registerAdvice(service);
+	}
+
+	@Reference(unbind = "-")
+	protected void setStaging(Staging staging) {
 	}
 
 	protected void unsetService(UserGroupLocalService service) {

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupLocalServiceStagingAdvice.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.staging.security.spring;
+
+import com.liferay.portal.service.UserGroupLocalService;
+
+/**
+ * @author Tomas Polesovsky
+ */
+public class UserGroupLocalServiceStagingAdvice extends LiveGroupStagingAdvice {
+
+	public UserGroupLocalServiceStagingAdvice() throws NoSuchMethodException {
+		super(UserGroupLocalService.class);
+
+		initGroupServiceBuilderMethods();
+
+		initCustomMethod("getGroupUserUserGroups", 0, long.class, long.class);
+	}
+
+}

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupRoleLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupRoleLocalServiceStagingAdvice.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.staging.security.spring;
+
+import com.liferay.portal.service.UserGroupRoleLocalService;
+
+/**
+ * @author Tomas Polesovsky
+ */
+public class UserGroupRoleLocalServiceStagingAdvice
+	extends LiveGroupStagingAdvice {
+
+	public UserGroupRoleLocalServiceStagingAdvice()
+		throws NoSuchMethodException {
+
+		super(UserGroupRoleLocalService.class);
+
+		initCustomMethod(
+			"addUserGroupRoles", 1, long.class, long.class, long[].class);
+		initCustomMethod(
+			"addUserGroupRoles", 1, long[].class, long.class, long.class);
+		initCustomMethod("deleteUserGroupRoles", 0, long.class, int.class);
+		initCustomMethod(
+			"deleteUserGroupRoles", 1, long.class, long.class, long[].class);
+		initCustomMethod("deleteUserGroupRoles", 1, long.class, long[].class);
+		initCustomMethod("deleteUserGroupRoles", 1, long[].class, long.class);
+		initCustomMethod(
+			"deleteUserGroupRoles", 1, long[].class, long.class, long.class);
+		initCustomMethod(
+			"deleteUserGroupRoles", 1, long[].class, long.class, int.class);
+		initCustomMethod("deleteUserGroupRolesByGroupId", 0, long.class);
+		initCustomMethod("getUserGroupRoles", 1, long.class, long.class);
+		initCustomMethod(
+			"getUserGroupRoles", 1, long.class, long.class, int.class,
+			int.class);
+		initCustomMethod("getUserGroupRolesByGroup", 0, long.class);
+		initCustomMethod(
+			"getUserGroupRolesByGroupAndRole", 0, long.class, long.class);
+		initCustomMethod(
+			"getUserGroupRolesByUserUserGroupAndGroup", 1, long.class,
+			long.class);
+		initCustomMethod("getUserGroupRolesCount", 1, long.class, long.class);
+		initCustomMethod(
+			"hasUserGroupRole", 1, long.class, long.class, long.class);
+		initCustomMethod(
+			"hasUserGroupRole", 1, long.class, long.class, long.class,
+			boolean.class);
+		initCustomMethod(
+			"hasUserGroupRole", 1, long.class, long.class, String.class);
+		initCustomMethod(
+			"hasUserGroupRole", 1, long.class, long.class, String.class,
+			boolean.class);
+	}
+
+}

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupRoleLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupRoleLocalServiceStagingAdvice.java
@@ -19,9 +19,13 @@ import com.liferay.portal.service.UserGroupRoleLocalService;
 import java.util.Arrays;
 import java.util.List;
 
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
 /**
  * @author Tomas Polesovsky
  */
+@Component(immediate = true)
 public class UserGroupRoleLocalServiceStagingAdvice
 	extends LiveGroupStagingAdvice {
 
@@ -67,6 +71,15 @@ public class UserGroupRoleLocalServiceStagingAdvice
 			boolean.class);
 
 		checkCoverage(_GROUP_METHODS_WHITELIST);
+	}
+
+	@Reference
+	protected void setService(UserGroupRoleLocalService service) {
+		registerAdvice(service);
+	}
+
+	protected void unsetService(UserGroupRoleLocalService service) {
+		unregisterAdvice(service);
 	}
 
 	private static final List<String> _GROUP_METHODS_WHITELIST = Arrays.asList(

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupRoleLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupRoleLocalServiceStagingAdvice.java
@@ -15,6 +15,7 @@
 package com.liferay.staging.security.spring;
 
 import com.liferay.portal.service.UserGroupRoleLocalService;
+import com.liferay.portlet.exportimport.staging.Staging;
 
 import java.util.Arrays;
 import java.util.List;
@@ -76,6 +77,10 @@ public class UserGroupRoleLocalServiceStagingAdvice
 	@Reference
 	protected void setService(UserGroupRoleLocalService service) {
 		registerAdvice(service);
+	}
+
+	@Reference(unbind = "-")
+	protected void setStaging(Staging staging) {
 	}
 
 	protected void unsetService(UserGroupRoleLocalService service) {

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupRoleLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupRoleLocalServiceStagingAdvice.java
@@ -16,6 +16,9 @@ package com.liferay.staging.security.spring;
 
 import com.liferay.portal.service.UserGroupRoleLocalService;
 
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * @author Tomas Polesovsky
  */
@@ -62,6 +65,11 @@ public class UserGroupRoleLocalServiceStagingAdvice
 		initCustomMethod(
 			"hasUserGroupRole", 1, long.class, long.class, String.class,
 			boolean.class);
+
+		checkCoverage(_GROUP_METHODS_WHITELIST);
 	}
+
+	private static final List<String> _GROUP_METHODS_WHITELIST = Arrays.asList(
+		new String[] {});
 
 }

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserLocalServiceStagingAdvice.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.staging.security.spring;
+
+import com.liferay.portal.service.ServiceContext;
+import com.liferay.portal.service.UserLocalService;
+
+/**
+ * @author Tomas Polesovsky
+ */
+public class UserLocalServiceStagingAdvice extends LiveGroupStagingAdvice {
+
+	public UserLocalServiceStagingAdvice() throws NoSuchMethodException {
+		super(UserLocalService.class);
+
+		initGroupServiceBuilderMethods();
+
+		initCustomMethod("getGroupUserIds", 0, long.class);
+
+		initCustomMethod(
+			"searchSocial", 1, long.class, long[].class, String.class,
+			int.class, int.class);
+
+		initCustomMethod(
+			"searchSocial", 0, long[].class, long.class, int[].class,
+			String.class, int.class, int.class);
+
+		initCustomMethod(
+			"updateGroups", 1, long.class, long[].class, ServiceContext.class);
+
+		initCustomMethod("unsetGroupTeamsUsers", 0, long.class, long[].class);
+	}
+
+}

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserLocalServiceStagingAdvice.java
@@ -16,6 +16,7 @@ package com.liferay.staging.security.spring;
 
 import com.liferay.portal.service.ServiceContext;
 import com.liferay.portal.service.UserLocalService;
+import com.liferay.portlet.exportimport.staging.Staging;
 
 import java.util.Arrays;
 import java.util.List;
@@ -55,6 +56,10 @@ public class UserLocalServiceStagingAdvice extends LiveGroupStagingAdvice {
 	@Reference
 	protected void setService(UserLocalService service) {
 		registerAdvice(service);
+	}
+
+	@Reference(unbind = "-")
+	protected void setStaging(Staging staging) {
 	}
 
 	protected void unsetService(UserLocalService service) {

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserLocalServiceStagingAdvice.java
@@ -20,9 +20,13 @@ import com.liferay.portal.service.UserLocalService;
 import java.util.Arrays;
 import java.util.List;
 
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
 /**
  * @author Tomas Polesovsky
  */
+@Component(immediate = true)
 public class UserLocalServiceStagingAdvice extends LiveGroupStagingAdvice {
 
 	public UserLocalServiceStagingAdvice() throws NoSuchMethodException {
@@ -46,6 +50,15 @@ public class UserLocalServiceStagingAdvice extends LiveGroupStagingAdvice {
 		initCustomMethod("unsetGroupTeamsUsers", 0, long.class, long[].class);
 
 		checkCoverage(_GROUP_METHODS_WHITELIST);
+	}
+
+	@Reference
+	protected void setService(UserLocalService service) {
+		registerAdvice(service);
+	}
+
+	protected void unsetService(UserLocalService service) {
+		unregisterAdvice(service);
 	}
 
 	private static final List<String> _GROUP_METHODS_WHITELIST =

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserLocalServiceStagingAdvice.java
@@ -17,6 +17,9 @@ package com.liferay.staging.security.spring;
 import com.liferay.portal.service.ServiceContext;
 import com.liferay.portal.service.UserLocalService;
 
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * @author Tomas Polesovsky
  */
@@ -41,6 +44,13 @@ public class UserLocalServiceStagingAdvice extends LiveGroupStagingAdvice {
 			"updateGroups", 1, long.class, long[].class, ServiceContext.class);
 
 		initCustomMethod("unsetGroupTeamsUsers", 0, long.class, long[].class);
+
+		checkCoverage(_GROUP_METHODS_WHITELIST);
 	}
+
+	private static final List<String> _GROUP_METHODS_WHITELIST =
+		Arrays.asList(new String[] {
+			"addDefaultGroups", "getGroupPrimaryKeys", "getNoGroups"
+		});
 
 }

--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -961,17 +961,20 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 					group.getGroupId(), RoleConstants.TYPE_SITE);
 			}
 			else {
+				if (!group.isStagingGroup() || group.isStagedRemotely()) {
+
+					// Group roles
+
+					userGroupRoleLocalService.deleteUserGroupRolesByGroupId(
+						group.getGroupId());
+
+					// User group roles
+
+					userGroupGroupRoleLocalService.
+						deleteUserGroupGroupRolesByGroupId(group.getGroupId());
+				}
+
 				groupPersistence.remove(group);
-
-				// Group roles
-
-				userGroupRoleLocalService.deleteUserGroupRolesByGroupId(
-					group.getGroupId());
-
-				// User group roles
-
-				userGroupGroupRoleLocalService.
-					deleteUserGroupGroupRolesByGroupId(group.getGroupId());
 			}
 
 			// Permission cache

--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -6184,14 +6184,14 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 
 		for (long oldGroupId : oldGroupIds) {
 			if (!ArrayUtil.contains(newGroupIds, oldGroupId)) {
-				unsetGroupUsers(
+				userLocalService.unsetGroupUsers(
 					oldGroupId, new long[] {userId}, serviceContext);
 			}
 		}
 
 		for (long newGroupId : newGroupIds) {
 			if (!ArrayUtil.contains(oldGroupIds, newGroupId)) {
-				addGroupUsers(newGroupId, new long[] {userId});
+				userLocalService.addGroupUsers(newGroupId, new long[] {userId});
 			}
 		}
 

--- a/portal-impl/src/com/liferay/portal/verify/VerifyGroup.java
+++ b/portal-impl/src/com/liferay/portal/verify/VerifyGroup.java
@@ -31,9 +31,18 @@ import com.liferay.portal.model.Group;
 import com.liferay.portal.model.GroupConstants;
 import com.liferay.portal.model.LayoutSet;
 import com.liferay.portal.model.Organization;
+import com.liferay.portal.model.Role;
 import com.liferay.portal.model.User;
+import com.liferay.portal.model.UserGroup;
+import com.liferay.portal.model.UserGroupGroupRole;
+import com.liferay.portal.model.UserGroupRole;
 import com.liferay.portal.service.CompanyLocalServiceUtil;
 import com.liferay.portal.service.GroupLocalServiceUtil;
+import com.liferay.portal.service.OrganizationLocalServiceUtil;
+import com.liferay.portal.service.RoleLocalServiceUtil;
+import com.liferay.portal.service.UserGroupGroupRoleLocalServiceUtil;
+import com.liferay.portal.service.UserGroupLocalServiceUtil;
+import com.liferay.portal.service.UserGroupRoleLocalServiceUtil;
 import com.liferay.portal.service.UserLocalServiceUtil;
 import com.liferay.portal.service.impl.GroupLocalServiceImpl;
 import com.liferay.portal.util.PortalInstances;
@@ -275,7 +284,42 @@ public class VerifyGroup extends VerifyProcess {
 
 				GroupLocalServiceUtil.updateGroup(stagingGroup);
 			}
+
+			if (!stagingGroup.isStagedRemotely()) {
+				verifyStagingGroupOrganizationMembership(stagingGroup);
+				verifyStagingGroupRoleMembership(stagingGroup);
+				verifyStagingGroupUserGroupMembership(stagingGroup);
+				verifyStagingGroupUserMembership(stagingGroup);
+				verifyStagingUserGroupRolesAssignments(stagingGroup);
+				verifyStagingUserGroupGroupRolesAssignments(stagingGroup);
+			}
 		}
+	}
+
+	protected void verifyStagingGroupOrganizationMembership(Group stagingGroup)
+		throws Exception {
+
+		List<Organization> staged =
+			OrganizationLocalServiceUtil.getGroupOrganizations(
+				stagingGroup.getGroupId());
+
+		if (staged.isEmpty()) {
+			return;
+		}
+
+		List<Organization> live =
+			OrganizationLocalServiceUtil.getGroupOrganizations(
+				stagingGroup.getLiveGroupId());
+
+		for (Organization organization : staged) {
+			if (!live.contains(organization)) {
+				OrganizationLocalServiceUtil.addGroupOrganization(
+					stagingGroup.getLiveGroupId(), organization);
+			}
+		}
+
+		OrganizationLocalServiceUtil.clearGroupOrganizations(
+			stagingGroup.getGroupId());
 	}
 
 	protected void verifyStagingTypeSettingsProperties(
@@ -306,6 +350,135 @@ public class VerifyGroup extends VerifyProcess {
 		for (long companyId : companyIds) {
 			GroupLocalServiceUtil.rebuildTree(companyId);
 		}
+	}
+
+	private void verifyStagingGroupRoleMembership(Group stagingGroup) {
+		List<Role> staged = RoleLocalServiceUtil.getGroupRoles(
+			stagingGroup.getGroupId());
+
+		if (staged.isEmpty()) {
+			return;
+		}
+
+		List<Role> live = RoleLocalServiceUtil.getGroupRoles(
+			stagingGroup.getLiveGroupId());
+
+		for (Role role : staged) {
+			if (!live.contains(role)) {
+				RoleLocalServiceUtil.addGroupRole(
+					stagingGroup.getLiveGroupId(), role);
+			}
+		}
+
+		RoleLocalServiceUtil.clearGroupRoles(stagingGroup.getGroupId());
+	}
+
+	private void verifyStagingGroupUserGroupMembership(Group stagingGroup) {
+		List<UserGroup> staged = UserGroupLocalServiceUtil.getGroupUserGroups(
+			stagingGroup.getGroupId());
+
+		if (staged.isEmpty()) {
+			return;
+		}
+
+		List<UserGroup> live = UserGroupLocalServiceUtil.getGroupUserGroups(
+			stagingGroup.getLiveGroupId());
+
+		for (UserGroup userGroup : staged) {
+			if (!live.contains(userGroup)) {
+				UserGroupLocalServiceUtil.addGroupUserGroup(
+					stagingGroup.getLiveGroupId(), userGroup);
+			}
+		}
+
+		UserGroupLocalServiceUtil.clearGroupUserGroups(
+			stagingGroup.getGroupId());
+	}
+
+	private void verifyStagingGroupUserMembership(Group stagingGroup) {
+		List<User> staged = UserLocalServiceUtil.getGroupUsers(
+			stagingGroup.getGroupId());
+
+		if (staged.isEmpty()) {
+			return;
+		}
+
+		List<User> live = UserLocalServiceUtil.getGroupUsers(
+			stagingGroup.getLiveGroupId());
+
+		for (User user : staged) {
+			if (!live.contains(user)) {
+				UserLocalServiceUtil.addGroupUser(
+					stagingGroup.getLiveGroupId(), user);
+			}
+		}
+
+		UserLocalServiceUtil.clearGroupUsers(stagingGroup.getGroupId());
+	}
+
+	private void verifyStagingUserGroupGroupRolesAssignments(
+		Group stagingGroup) {
+
+		DynamicQuery dynamicQuery =
+			UserGroupGroupRoleLocalServiceUtil.dynamicQuery();
+
+		dynamicQuery.add(
+			RestrictionsFactoryUtil.eq(
+				"id.groupId", stagingGroup.getGroupId()));
+
+		List<UserGroupGroupRole> staged =
+			UserGroupGroupRoleLocalServiceUtil.dynamicQuery(dynamicQuery);
+
+		if (staged.isEmpty()) {
+			return;
+		}
+
+		dynamicQuery = UserGroupGroupRoleLocalServiceUtil.dynamicQuery();
+
+		dynamicQuery.add(
+			RestrictionsFactoryUtil.eq(
+				"id.groupId", stagingGroup.getLiveGroupId()));
+
+		List<UserGroupGroupRole> live =
+			UserGroupGroupRoleLocalServiceUtil.dynamicQuery(dynamicQuery);
+
+		for (UserGroupGroupRole userGroupGroupRole : staged) {
+			userGroupGroupRole.setGroupId(stagingGroup.getLiveGroupId());
+
+			if (!live.contains(userGroupGroupRole)) {
+				UserGroupGroupRoleLocalServiceUtil.updateUserGroupGroupRole(
+					userGroupGroupRole);
+			}
+		}
+
+		UserGroupGroupRoleLocalServiceUtil.deleteUserGroupGroupRolesByGroupId(
+			stagingGroup.getGroupId());
+	}
+
+	private void verifyStagingUserGroupRolesAssignments(Group stagingGroup) {
+		List<UserGroupRole> staged =
+			UserGroupRoleLocalServiceUtil.getUserGroupRolesByGroup(
+				stagingGroup.getGroupId());
+
+		if (staged.isEmpty()) {
+			return;
+		}
+
+		List<UserGroupRole> live =
+			UserGroupRoleLocalServiceUtil.getUserGroupRolesByGroup(
+				stagingGroup.getLiveGroupId());
+
+		for (UserGroupRole userGroupRole : staged) {
+			userGroupRole.setGroupId(stagingGroup.getLiveGroupId());
+
+			if (!live.contains(userGroupRole)) {
+				UserGroupRoleLocalServiceUtil.updateUserGroupRole(
+					userGroupRole);
+			}
+		}
+
+		UserGroupRoleLocalServiceUtil.deleteUserGroupRolesByGroupId(
+			stagingGroup.getGroupId());
 	}
 
 	private static final String[] _LEGACY_STAGED_PORTLET_TYPE_SETTINGS_KEYS = {


### PR DESCRIPTION
Hi Mate,

this is the second part for the staging permissions (https://github.com/topolik/liferay-portal/pull/228). The core idea is that once we check permissions only on live groups, the roles assignment and group membership should be done only on live groups. 

So the commits exchange staging groupId for live groupId in selected services using advices.

Thanks!