### PR TITLE
[TECHNICAL-SUPPORT] LPS-60568 Asset Publisher's scope settings are not published to remote Live

### DIFF
--- a/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/lar/test/AssetPublisherExportImportTest.java
+++ b/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/lar/test/AssetPublisherExportImportTest.java
@@ -73,6 +73,7 @@ import com.liferay.portlet.documentlibrary.service.DLFileEntryTypeLocalServiceUt
 import com.liferay.portlet.exportimport.configuration.ExportImportConfigurationConstants;
 import com.liferay.portlet.exportimport.configuration.ExportImportConfigurationSettingsMapFactory;
 import com.liferay.portlet.exportimport.lar.ExportImportHelperUtil;
+import com.liferay.portlet.exportimport.lar.ExportImportThreadLocal;
 import com.liferay.portlet.exportimport.lar.PortletDataHandlerKeys;
 import com.liferay.portlet.exportimport.model.ExportImportConfiguration;
 import com.liferay.portlet.exportimport.service.ExportImportConfigurationLocalServiceUtil;
@@ -916,6 +917,41 @@ public class AssetPublisherExportImportTest
 	@Test
 	public void testSortByGlobalAssetVocabulary() throws Exception {
 		testSortByAssetVocabulary(true);
+	}
+
+	@Test
+	public void testStagingGroupScopeId() throws Exception {
+		Map<String, String[]> preferenceMap = new HashMap<>();
+
+		Group liveGroup = GroupTestUtil.addGroup();
+
+		GroupTestUtil.enableLocalStaging(liveGroup);
+
+		Group stagingGroup = liveGroup.getStagingGroup();
+
+		preferenceMap.put(
+			"scopeIds",
+			new String[] {
+				AssetPublisherUtil.SCOPE_ID_GROUP_PREFIX +
+					stagingGroup.getGroupId()
+			});
+
+		try {
+			ExportImportThreadLocal.setLayoutStagingInProcess(true);
+
+			PortletPreferences portletPreferences =
+				getImportedPortletPreferences(preferenceMap);
+
+			Assert.assertEquals(
+				AssetPublisherUtil.SCOPE_ID_GROUP_PREFIX +
+					liveGroup.getGroupId(),
+				portletPreferences.getValue("scopeIds", null));
+			Assert.assertEquals(
+				null, portletPreferences.getValue("scopeId", null));
+		}
+		finally {
+			ExportImportThreadLocal.setLayoutStagingInProcess(false);
+		}
 	}
 
 	protected List<AssetEntry> addAssetEntries(


### PR DESCRIPTION
Hey Máté,

The Asset Publisher portlet already handles the default (where the AP is placed), global, and layout related groups.

However, if another group is selected which is staged, the settings will be lost.

This fix replaces the groupId with the liveGroupId if staging is enabled (for LAR export/import we don't want to change the groupId), so during the import the Live group will be used.


Actually, the issue is not reproducible currently wit  Local staging, as we cannot select the staging group on the UI, but it seems safer to prepare the Portal to handle this problem for Locale staging as well.
I added a test method to validate my fix with Local staging.

Thanks,
Tamás