### PR TITLE
LPS-56312 An excepcion of "layoutset does not exists" is thrown during Staging Activation

### DIFF
--- a/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/background/task/LayoutStagingBackgroundTaskExecutor.java
+++ b/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/background/task/LayoutStagingBackgroundTaskExecutor.java
@@ -26,7 +26,9 @@ import com.liferay.exportimport.kernel.model.ExportImportConfiguration;
 import com.liferay.exportimport.kernel.service.ExportImportLocalServiceUtil;
 import com.liferay.exportimport.kernel.service.StagingLocalServiceUtil;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTask;
+import com.liferay.portal.kernel.backgroundtask.BackgroundTaskConstants;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskExecutor;
+import com.liferay.portal.kernel.backgroundtask.BackgroundTaskManagerUtil;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskResult;
 import com.liferay.portal.kernel.exception.NoSuchGroupException;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -45,6 +47,7 @@ import com.liferay.portal.kernel.util.UnicodeProperties;
 import java.io.File;
 import java.io.Serializable;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
@@ -171,6 +174,19 @@ public class LayoutStagingBackgroundTaskExecutor
 
 				StagingLocalServiceUtil.disableStaging(
 					sourceGroup, serviceContext);
+
+				List<BackgroundTask> pendingTasks =
+					BackgroundTaskManagerUtil.getBackgroundTasks(
+						sourceGroupId,
+						LayoutStagingBackgroundTaskExecutor.class.getName(),
+						BackgroundTaskConstants.STATUS_QUEUED);
+
+				for (BackgroundTask pendingTask : pendingTasks) {
+					BackgroundTaskManagerUtil.amendBackgroundTask(
+						pendingTask.getBackgroundTaskId(), null,
+						BackgroundTaskConstants.STATUS_CANCELLED,
+						new ServiceContext());
+				}
 			}
 
 			deleteTempLarOnFailure(file);

--- a/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/background/task/LayoutStagingBackgroundTaskExecutor.java
+++ b/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/background/task/LayoutStagingBackgroundTaskExecutor.java
@@ -28,6 +28,7 @@ import com.liferay.exportimport.kernel.service.StagingLocalServiceUtil;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTask;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskExecutor;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskResult;
+import com.liferay.portal.kernel.exception.NoSuchGroupException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.log.Log;
@@ -94,6 +95,14 @@ public class LayoutStagingBackgroundTaskExecutor
 
 		try {
 			ExportImportThreadLocal.setLayoutStagingInProcess(true);
+
+			Group targetGroup = GroupLocalServiceUtil.fetchGroup(targetGroupId);
+
+			if (targetGroup == null) {
+				throw new NoSuchGroupException(
+					"Target group does not exists with the primary key " +
+						targetGroupId);
+			}
 
 			Group sourceGroup = GroupLocalServiceUtil.getGroup(sourceGroupId);
 

--- a/modules/apps/web-experience/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/lifecycle/test/ExportImportLifecycleEventTest.java
+++ b/modules/apps/web-experience/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/lifecycle/test/ExportImportLifecycleEventTest.java
@@ -196,16 +196,15 @@ public class ExportImportLifecycleEventTest {
 
 			Throwable throwable = throwableInformation.getThrowable();
 
-			Assert.assertSame(
-				NoSuchLayoutSetException.class, throwable.getClass());
+			Assert.assertSame(NoSuchGroupException.class, throwable.getClass());
 
 			loggingEvents = captureAppender2.getLoggingEvents();
 
 			loggingEvent = loggingEvents.get(0);
 
 			Assert.assertEquals(
-				"Unable to publish layout: No LayoutSet exists with the key " +
-					"{groupId=" + targetGroupId + ", privateLayout=false}",
+				"Unable to publish layout: Target group does not exists with " +
+					"the primary key " + targetGroupId,
 				loggingEvent.getMessage());
 		}
 


### PR DESCRIPTION
Hi @matethurzo 

I have been doing some tests at master with a real database of a customer upgraded from 6.2 to 7.0 and this is one of the issues I have detected:
   - public pages activation process spends 4 hours and after that time a NPE is thrown. So staging group is deleted
   - but after that private pages activation process is executed and after one hour of export process this "layoutset does not exists" is thrown because at public page process we deleted the group.

This code avoids spending 1 hour of export process for private pages when we know that it is going to fail for sure.