### PR TITLE
LPS-71134 Add test case for imports with default data

### DIFF
--- a/modules/apps/collaboration/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/exportimport/data/handler/WikiNodeStagedModelDataHandler.java
+++ b/modules/apps/collaboration/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/exportimport/data/handler/WikiNodeStagedModelDataHandler.java
@@ -132,16 +132,16 @@ public class WikiNodeStagedModelDataHandler
 		WikiNode existingNode = fetchStagedModelByUuidAndGroupId(
 			node.getUuid(), portletDataContext.getScopeGroupId());
 
-		WikiNode nodeWithSameName = _wikiNodeLocalService.fetchNode(
-			portletDataContext.getGroupId(), node.getName());
-
 		String nodeName = node.getName();
+
+		WikiNode nodeWithSameName = _wikiNodeLocalService.fetchNode(
+			portletDataContext.getGroupId(), nodeName);
 
 		if (portletDataContext.isDataStrategyMirror()) {
 			if (existingNode == null) {
 				if (nodeWithSameName != null) {
 					nodeName = getNodeName(
-						portletDataContext, node, node.getName(), 2);
+						portletDataContext, node, nodeName, 2);
 				}
 
 				serviceContext.setUuid(node.getUuid());

--- a/modules/apps/collaboration/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/exportimport/data/handler/WikiNodeStagedModelDataHandler.java
+++ b/modules/apps/collaboration/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/exportimport/data/handler/WikiNodeStagedModelDataHandler.java
@@ -153,8 +153,7 @@ public class WikiNodeStagedModelDataHandler
 				String uuid = existingNode.getUuid();
 
 				if ((nodeWithSameName != null) &&
-					!uuid.equals(nodeWithSameName.getUuid()) &&
-					!nodeName.equals(existingNode.getName())) {
+					!uuid.equals(nodeWithSameName.getUuid())) {
 
 					nodeName = getNodeName(
 						portletDataContext, node, nodeName, 2);

--- a/modules/apps/collaboration/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/exportimport/data/handler/WikiNodeStagedModelDataHandler.java
+++ b/modules/apps/collaboration/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/exportimport/data/handler/WikiNodeStagedModelDataHandler.java
@@ -132,18 +132,37 @@ public class WikiNodeStagedModelDataHandler
 		WikiNode existingNode = fetchStagedModelByUuidAndGroupId(
 			node.getUuid(), portletDataContext.getScopeGroupId());
 
+		WikiNode nodeWithSameName = _wikiNodeLocalService.fetchNode(
+			portletDataContext.getGroupId(), node.getName());
+
+		String nodeName = node.getName();
+
 		if (portletDataContext.isDataStrategyMirror()) {
 			if (existingNode == null) {
+				if (nodeWithSameName != null) {
+					nodeName = getNodeName(
+						portletDataContext, node, node.getName(), 2);
+				}
+
 				serviceContext.setUuid(node.getUuid());
 
 				importedNode = _wikiNodeLocalService.addNode(
-					userId, node.getName(), node.getDescription(),
-					serviceContext);
+					userId, nodeName, node.getDescription(), serviceContext);
 			}
 			else {
+				String uuid = existingNode.getUuid();
+
+				if ((nodeWithSameName != null) &&
+					!uuid.equals(nodeWithSameName.getUuid()) &&
+					!nodeName.equals(existingNode.getName())) {
+
+					nodeName = getNodeName(
+						portletDataContext, node, nodeName, 2);
+				}
+
 				importedNode = _wikiNodeLocalService.updateNode(
-					existingNode.getNodeId(), node.getName(),
-					node.getDescription(), serviceContext);
+					existingNode.getNodeId(), nodeName, node.getDescription(),
+					serviceContext);
 			}
 		}
 		else {
@@ -154,12 +173,11 @@ public class WikiNodeStagedModelDataHandler
 				initialNodeName.equals(existingNode.getName())) {
 
 				importedNode = _wikiNodeLocalService.updateNode(
-					existingNode.getNodeId(), node.getName(),
-					node.getDescription(), serviceContext);
+					existingNode.getNodeId(), nodeName, node.getDescription(),
+					serviceContext);
 			}
 			else {
-				String nodeName = getNodeName(
-					portletDataContext, node, node.getName(), 2);
+				nodeName = getNodeName(portletDataContext, node, nodeName, 2);
 
 				importedNode = _wikiNodeLocalService.addNode(
 					userId, nodeName, node.getDescription(), serviceContext);

--- a/modules/apps/collaboration/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/exportimport/data/handler/WikiNodeStagedModelDataHandler.java
+++ b/modules/apps/collaboration/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/exportimport/data/handler/WikiNodeStagedModelDataHandler.java
@@ -135,7 +135,7 @@ public class WikiNodeStagedModelDataHandler
 		String nodeName = node.getName();
 
 		WikiNode nodeWithSameName = _wikiNodeLocalService.fetchNode(
-			portletDataContext.getGroupId(), nodeName);
+			portletDataContext.getScopeGroupId(), nodeName);
 
 		if (portletDataContext.isDataStrategyMirror()) {
 			if (existingNode == null) {

--- a/modules/apps/collaboration/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/internal/exportimport/data/handler/test/WikiNodeStagedModelDataHandlerTest.java
+++ b/modules/apps/collaboration/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/internal/exportimport/data/handler/test/WikiNodeStagedModelDataHandlerTest.java
@@ -50,6 +50,15 @@ public class WikiNodeStagedModelDataHandlerTest
 			SynchronousDestinationTestRule.INSTANCE);
 
 	@Override
+	protected StagedModel addDefaultStagedModel(
+			Group group,
+			Map<String, List<StagedModel>> dependentStagedModelsMap)
+		throws Exception {
+
+		return WikiTestUtil.addDefaultNode(group.getGroupId());
+	}
+
+	@Override
 	protected StagedModel addStagedModel(
 			Group group,
 			Map<String, List<StagedModel>> dependentStagedModelsMap)

--- a/modules/apps/collaboration/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/internal/exportimport/data/handler/test/WikiPageStagedModelDataHandlerTest.java
+++ b/modules/apps/collaboration/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/internal/exportimport/data/handler/test/WikiPageStagedModelDataHandlerTest.java
@@ -71,6 +71,30 @@ public class WikiPageStagedModelDataHandlerTest
 			SynchronousDestinationTestRule.INSTANCE);
 
 	@Override
+	protected Map<String, List<StagedModel>> addDefaultDependentStagedModelsMap(
+			Group group)
+		throws Exception {
+
+		Map<String, List<StagedModel>> dependentStagedModelsMap =
+			new HashMap<>();
+
+		WikiNode node = WikiTestUtil.addDefaultNode(group.getGroupId());
+
+		addDependentStagedModel(dependentStagedModelsMap, WikiNode.class, node);
+
+		return dependentStagedModelsMap;
+	}
+
+	@Override
+	protected StagedModel addDefaultStagedModel(
+			Group group,
+			Map<String, List<StagedModel>> dependentStagedModelsMap)
+		throws Exception {
+
+		return addStagedModel(group, dependentStagedModelsMap, "Front Page");
+	}
+
+	@Override
 	protected Map<String, List<StagedModel>> addDependentStagedModelsMap(
 			Group group)
 		throws Exception {
@@ -91,6 +115,16 @@ public class WikiPageStagedModelDataHandlerTest
 			Map<String, List<StagedModel>> dependentStagedModelsMap)
 		throws Exception {
 
+		return addStagedModel(
+			group, dependentStagedModelsMap, RandomTestUtil.randomString());
+	}
+
+	protected StagedModel addStagedModel(
+			Group group,
+			Map<String, List<StagedModel>> dependentStagedModelsMap,
+			String name)
+		throws Exception {
+
 		List<StagedModel> dependentStagedModels = dependentStagedModelsMap.get(
 			WikiNode.class.getSimpleName());
 
@@ -100,9 +134,8 @@ public class WikiPageStagedModelDataHandlerTest
 			ServiceContextTestUtil.getServiceContext(group.getGroupId());
 
 		WikiPage page = WikiTestUtil.addPage(
-			TestPropsValues.getUserId(), node.getNodeId(),
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(), true,
-			serviceContext);
+			TestPropsValues.getUserId(), node.getNodeId(), name,
+			RandomTestUtil.randomString(), true, serviceContext);
 
 		WikiTestUtil.addWikiAttachment(
 			TestPropsValues.getUserId(), node.getNodeId(), page.getTitle(),

--- a/modules/apps/collaboration/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/util/test/WikiTestUtil.java
+++ b/modules/apps/collaboration/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/util/test/WikiTestUtil.java
@@ -43,6 +43,22 @@ import java.util.Map;
  */
 public class WikiTestUtil {
 
+	public static WikiNode addDefaultNode(long groupId) throws Exception {
+		WorkflowThreadLocal.setEnabled(true);
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(groupId);
+
+		serviceContext.setWorkflowAction(WorkflowConstants.ACTION_SAVE_DRAFT);
+
+		serviceContext = (ServiceContext)serviceContext.clone();
+
+		WikiNode node = WikiNodeLocalServiceUtil.addDefaultNode(
+			TestPropsValues.getUserId(), serviceContext);
+
+		return node;
+	}
+
 	public static WikiNode addNode(long groupId) throws Exception {
 		return addNode(
 			TestPropsValues.getUserId(), groupId, RandomTestUtil.randomString(),

--- a/portal-test-integration/src/com/liferay/portal/lar/test/BaseStagedModelDataHandlerTestCase.java
+++ b/portal-test-integration/src/com/liferay/portal/lar/test/BaseStagedModelDataHandlerTestCase.java
@@ -149,6 +149,59 @@ public abstract class BaseStagedModelDataHandlerTestCase {
 			portletDataContext, exportedStagedModel);
 	}
 
+	@Test
+	public void testExportImportWithDefaultData() throws Exception {
+
+		// Export default data
+
+		initExport();
+
+		Map<String, List<StagedModel>> dependentStagedModelsMap =
+			addDefaultDependentStagedModelsMap(stagingGroup);
+
+		StagedModel stagedModel = addDefaultStagedModel(
+			stagingGroup, dependentStagedModelsMap);
+
+		if (stagedModel == null) {
+			return;
+		}
+
+		StagedModelDataHandlerUtil.exportStagedModel(
+			portletDataContext, stagedModel);
+
+		validateExport(
+			portletDataContext, stagedModel, dependentStagedModelsMap);
+
+		// Add default data to live site
+
+		Map<String, List<StagedModel>> secondDependentStagedModelsMap =
+			addDefaultDependentStagedModelsMap(liveGroup);
+
+		addDefaultStagedModel(liveGroup, secondDependentStagedModelsMap);
+
+		// Import
+
+		initImport();
+
+		StagedModel exportedStagedModel = readExportedStagedModel(stagedModel);
+
+		Assert.assertNotNull(exportedStagedModel);
+
+		StagedModelDataHandlerUtil.importStagedModel(
+			portletDataContext, exportedStagedModel);
+
+		// Import again
+
+		StagedModelDataHandlerUtil.importStagedModel(
+			portletDataContext, exportedStagedModel);
+
+		String uuid = exportedStagedModel.getUuid();
+
+		StagedModel importedModel = getStagedModel(uuid, liveGroup);
+
+		Assert.assertNotNull(importedModel);
+	}
+
 	public void testLastPublishDate() throws Exception {
 		if (!supportLastPublishDateUpdate()) {
 			return;
@@ -367,6 +420,21 @@ public abstract class BaseStagedModelDataHandlerTestCase {
 			user.getFullName(), RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(50),
 			new IdentityServiceContextFunction(serviceContext));
+	}
+
+	protected Map<String, List<StagedModel>> addDefaultDependentStagedModelsMap(
+			Group group)
+		throws Exception {
+
+		return new HashMap<>();
+	}
+
+	protected StagedModel addDefaultStagedModel(
+			Group group,
+			Map<String, List<StagedModel>> dependentStagedModelsMap)
+		throws Exception {
+
+		return null;
 	}
 
 	protected List<StagedModel> addDependentStagedModel(


### PR DESCRIPTION
Hey Mate,

This is a pull from support. I have already reviewed the wiki logic and it looks good. I asked them to create a test for that, and I would like to you review the test, as it affects staging tests globally.

Let @Alec-Shay know if you have any concern.

Thanks @matethurzo 

This is the description that I had in my original pull from @Alec-Shay 

----

/cc @SamZiemer @jonathanmccann

Re-sending from #3850 with the changes you mentioned.

I implemented an integration test for a standard export/import between sites with default data. I also somewhat wanted to make the test more robust by including imports with different import strategies, but I knew at least in one case this would fail due to known bugs. For instance, see: LPS-71177.

Please let me know if there are any other problems with this to be addressed. Thank you.

For notes from the previous pull, please see: SamZiemer#209 (comment)