### PR TITLE
LPS-72250 Edited value from comment does not get published to live

### DIFF
--- a/modules/apps/collaboration/comment/comment-page-comments-web/src/main/java/com/liferay/comment/page/comments/web/internal/exportimport/data/handler/PageCommentsPortletDataHandler.java
+++ b/modules/apps/collaboration/comment/comment-page-comments-web/src/main/java/com/liferay/comment/page/comments/web/internal/exportimport/data/handler/PageCommentsPortletDataHandler.java
@@ -18,6 +18,7 @@ import com.liferay.comment.page.comments.web.internal.constants.PageCommentsPort
 import com.liferay.exportimport.kernel.lar.BasePortletDataHandler;
 import com.liferay.exportimport.kernel.lar.ExportImportProcessCallbackRegistryUtil;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
+import com.liferay.exportimport.kernel.lar.PortletDataContextFactoryUtil;
 import com.liferay.exportimport.kernel.lar.PortletDataHandler;
 import com.liferay.exportimport.kernel.lar.PortletDataHandlerBoolean;
 import com.liferay.exportimport.kernel.lar.PortletDataHandlerControl;
@@ -160,8 +161,13 @@ public class PageCommentsPortletDataHandler extends BasePortletDataHandler {
 			PortletPreferences portletPreferences, String data)
 		throws Exception {
 
+		PortletDataContext clonedPortletDataContext =
+			PortletDataContextFactoryUtil.clonePortletDataContext(
+				portletDataContext);
+
 		ExportImportProcessCallbackRegistryUtil.registerCallback(
-			new ImportCommentsCallable(portletDataContext));
+			portletDataContext.getExportImportProcessId(),
+			new ImportCommentsCallable(clonedPortletDataContext));
 
 		return null;
 	}

--- a/modules/apps/collaboration/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/exportimport/data/handler/MBDiscussionStagedModelDataHandler.java
+++ b/modules/apps/collaboration/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/exportimport/data/handler/MBDiscussionStagedModelDataHandler.java
@@ -20,6 +20,7 @@ import com.liferay.exportimport.data.handler.base.BaseStagedModelDataHandler;
 import com.liferay.exportimport.kernel.lar.ExportImportPathUtil;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandler;
+import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerRegistryUtil;
 import com.liferay.exportimport.kernel.lar.StagedModelModifiedDateComparator;
 import com.liferay.message.boards.kernel.model.MBDiscussion;
 import com.liferay.message.boards.kernel.model.MBMessage;
@@ -27,7 +28,14 @@ import com.liferay.message.boards.kernel.model.MBThread;
 import com.liferay.message.boards.kernel.service.MBDiscussionLocalService;
 import com.liferay.message.boards.kernel.service.MBMessageLocalService;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.PersistedModel;
+import com.liferay.portal.kernel.model.StagedModel;
+import com.liferay.portal.kernel.service.PersistedModelLocalService;
+import com.liferay.portal.kernel.service.PersistedModelLocalServiceRegistryUtil;
 import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.kernel.xml.Element;
 
@@ -106,6 +114,24 @@ public class MBDiscussionStagedModelDataHandler
 		Element discussionElement = portletDataContext.getExportDataElement(
 			discussion);
 
+		PersistedModelLocalService persistedModelLocalService =
+			PersistedModelLocalServiceRegistryUtil.
+				getPersistedModelLocalService(discussion.getClassName());
+
+		PersistedModel persistedModel =
+			persistedModelLocalService.getPersistedModel(
+				discussion.getClassPK());
+
+		if (!(persistedModel instanceof StagedModel)) {
+			return;
+		}
+
+		StagedModel stagedModel = (StagedModel)persistedModel;
+
+		String relatedModelUUID = stagedModel.getUuid();
+
+		discussionElement.addAttribute("relatedModelUUID", relatedModelUUID);
+
 		portletDataContext.addClassedModel(
 			discussionElement, ExportImportPathUtil.getModelPath(discussion),
 			discussion);
@@ -124,7 +150,34 @@ public class MBDiscussionStagedModelDataHandler
 			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(className);
 
 		long newClassPK = MapUtil.getLong(
-			relatedClassPKs, discussion.getClassPK(), discussion.getClassPK());
+			relatedClassPKs, discussion.getClassPK(), 0);
+
+		if (newClassPK == 0) {
+			Element discussionElement = portletDataContext.getImportDataElement(
+				discussion);
+
+			String relatedModelUUID = discussionElement.attributeValue(
+				"relatedModelUUID", StringPool.BLANK);
+
+			if (Validator.isNull(relatedModelUUID)) {
+				throw new PortalException(
+					"Missing related model UUID while importing discussion " +
+						discussion);
+			}
+
+			StagedModel stagedModel = _getRelatedStagedModel(
+				portletDataContext.getScopeGroupId(), className,
+				relatedModelUUID);
+
+			if (stagedModel == null) {
+				throw new PortalException(
+					"Couldn't find related model with className " + className +
+						", UUID " + relatedModelUUID + " in group " +
+							portletDataContext.getScopeGroupId());
+			}
+
+			newClassPK = (long)stagedModel.getPrimaryKeyObj();
+		}
 
 		MBDiscussion existingDiscussion =
 			_mbDiscussionLocalService.fetchDiscussion(
@@ -174,6 +227,17 @@ public class MBDiscussionStagedModelDataHandler
 		MBMessageLocalService mbMessageLocalService) {
 
 		_mbMessageLocalService = mbMessageLocalService;
+	}
+
+	private StagedModel _getRelatedStagedModel(
+		long groupId, String className, String uuid) {
+
+		StagedModelDataHandler<?> stagedModelDataHandler =
+			StagedModelDataHandlerRegistryUtil.getStagedModelDataHandler(
+				className);
+
+		return stagedModelDataHandler.fetchStagedModelByUuidAndGroupId(
+			uuid, groupId);
 	}
 
 	private AssetEntryLocalService _assetEntryLocalService;


### PR DESCRIPTION
Hey @matethurzo

I'm sending this to you because the "fix" is ugly beyond words, and
I'm pretty sure that I'm missing something here, because this kind of
problem must be common.

So, the problem here is that, when publishing a standalone
comment (i.e. not as part of its related model publication), there's
no way of getting the Live discussion itself in order to decide what
needs to be done (i.e. there's no generic service to get elements by
className/classPK).

Here I had to make a ton of assumptions about the related model:

  - It is a PersistedModel
  - It is a StagedModel
  - The classPK is the same as the primaryKey of the stagedModel

I'm pretty sure this won't hold in all the cases (cannot point to a
particular example, though), but I don't see how we can get the
related model in any other way.

An alternative solution that occurs to me is to export/import the
related model (FileEntry, BlogsEntry, etc.) if any of the comments
changed, disregarding the state of the related model itself. This
would make the changes in the second commit unnecessary, but I'm not
sure which is the best way to implement that.

Any thoughts about all this?