### PR TITLE
[not to merge] LPS-72546 Programatically disable SystemEvents

### DIFF
--- a/modules/apps/collaboration/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/capabilities/TemporaryFileEntriesCapabilityImpl.java
+++ b/modules/apps/collaboration/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/capabilities/TemporaryFileEntriesCapabilityImpl.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.repository.model.BaseRepositoryModelOperation;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.systemevent.SystemEventDynamicVariable;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.StringBundler;
@@ -107,9 +108,11 @@ public class TemporaryFileEntriesCapabilityImpl
 					System.currentTimeMillis() -
 						getTemporaryFileEntriesTimeout()));
 
-		bulkOperationCapability.execute(
-			bulkFilter,
-			new DeleteExpiredTemporaryFilesRepositoryModelOperation());
+		SystemEventDynamicVariable.ENABLED.withValue(
+			false,
+			() -> bulkOperationCapability.execute(
+				bulkFilter,
+				new DeleteExpiredTemporaryFilesRepositoryModelOperation()));
 	}
 
 	@Override
@@ -122,7 +125,10 @@ public class TemporaryFileEntriesCapabilityImpl
 			FileEntry fileEntry = getTemporaryFileEntry(
 				temporaryFileEntriesScope, fileName);
 
-			_documentRepository.deleteFileEntry(fileEntry.getFileEntryId());
+			SystemEventDynamicVariable.ENABLED.withValue(
+				false,
+				() -> _documentRepository.deleteFileEntry(
+					fileEntry.getFileEntryId()));
 		}
 		catch (NoSuchModelException nsme) {
 
@@ -142,9 +148,11 @@ public class TemporaryFileEntriesCapabilityImpl
 		try {
 			Folder folder = addTempFolder(temporaryFileEntriesScope);
 
-			return _documentRepository.getRepositoryFileEntries(
-				temporaryFileEntriesScope.getUserId(), folder.getFolderId(),
-				QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+			return SystemEventDynamicVariable.ENABLED.withValue(
+				false,
+				() -> _documentRepository.getRepositoryFileEntries(
+					temporaryFileEntriesScope.getUserId(), folder.getFolderId(),
+					QueryUtil.ALL_POS, QueryUtil.ALL_POS, null));
 		}
 		catch (NoSuchModelException nsme) {
 

--- a/portal-impl/src/com/liferay/portal/repository/temporaryrepository/TemporaryFileEntryRepository.java
+++ b/portal-impl/src/com/liferay/portal/repository/temporaryrepository/TemporaryFileEntryRepository.java
@@ -24,9 +24,11 @@ import com.liferay.document.library.kernel.service.DLFileVersionLocalService;
 import com.liferay.document.library.kernel.service.DLFileVersionService;
 import com.liferay.document.library.kernel.service.DLFolderLocalService;
 import com.liferay.document.library.kernel.service.DLFolderService;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.service.RepositoryLocalService;
 import com.liferay.portal.kernel.service.RepositoryService;
 import com.liferay.portal.kernel.service.ResourceLocalService;
+import com.liferay.portal.kernel.systemevent.SystemEventDynamicVariable;
 import com.liferay.portal.repository.liferayrepository.LiferayRepository;
 
 /**
@@ -57,6 +59,59 @@ public class TemporaryFileEntryRepository extends LiferayRepository {
 			dlFileShortcutService, dlFileVersionLocalService,
 			dlFileVersionService, dlFolderLocalService, dlFolderService,
 			resourceLocalService, groupId, repositoryId, dlFolderId);
+	}
+
+	@Override
+	public void deleteAll() {
+		SystemEventDynamicVariable.ENABLED.withValue(false, super::deleteAll);
+	}
+
+	@Override
+	public void deleteFileEntry(long fileEntryId) throws PortalException {
+		SystemEventDynamicVariable.ENABLED.withValue(
+			false, () -> super.deleteFileEntry(fileEntryId));
+	}
+
+	@Override
+	public void deleteFileEntry(long folderId, String title)
+		throws PortalException {
+
+		SystemEventDynamicVariable.ENABLED.withValue(
+			false, () -> super.deleteFileEntry(folderId, title));
+	}
+
+	@Override
+	public void deleteFileShortcut(long fileShortcutId) throws PortalException {
+		SystemEventDynamicVariable.ENABLED.withValue(
+			false, () -> super.deleteFileShortcut(fileShortcutId));
+	}
+
+	@Override
+	public void deleteFileShortcuts(long toFileEntryId) throws PortalException {
+		SystemEventDynamicVariable.ENABLED.withValue(
+			false, () -> super.deleteFileShortcuts(toFileEntryId));
+	}
+
+	@Override
+	public void deleteFileVersion(long fileEntryId, String version)
+		throws PortalException {
+
+		SystemEventDynamicVariable.ENABLED.withValue(
+			false, () -> super.deleteFileVersion(fileEntryId, version));
+	}
+
+	@Override
+	public void deleteFolder(long folderId) throws PortalException {
+		SystemEventDynamicVariable.ENABLED.withValue(
+			false, () -> super.deleteFolder(folderId));
+	}
+
+	@Override
+	public void deleteFolder(long parentFolderId, String name)
+		throws PortalException {
+
+		SystemEventDynamicVariable.ENABLED.withValue(
+			false, () -> super.deleteFolder(parentFolderId, name));
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/service/impl/SystemEventLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/SystemEventLocalServiceImpl.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.systemevent.SystemEventDynamicVariable;
 import com.liferay.portal.kernel.systemevent.SystemEventHierarchyEntry;
 import com.liferay.portal.kernel.systemevent.SystemEventHierarchyEntryThreadLocal;
 import com.liferay.portal.kernel.util.StringPool;
@@ -43,6 +44,10 @@ public class SystemEventLocalServiceImpl
 			String classUuid, String referrerClassName, int type,
 			String extraData)
 		throws PortalException {
+
+		if (!SystemEventDynamicVariable.ENABLED.getValue()) {
+			return null;
+		}
 
 		if (userId == 0) {
 			userId = PrincipalThreadLocal.getUserId();
@@ -73,6 +78,10 @@ public class SystemEventLocalServiceImpl
 			long companyId, String className, long classPK, String classUuid,
 			String referrerClassName, int type, String extraData)
 		throws PortalException {
+
+		if (!SystemEventDynamicVariable.ENABLED.getValue()) {
+			return null;
+		}
 
 		return addSystemEvent(
 			0, companyId, 0, className, classPK, classUuid, referrerClassName,

--- a/portal-impl/src/com/liferay/portal/systemevent/SystemEventAdvice.java
+++ b/portal-impl/src/com/liferay/portal/systemevent/SystemEventAdvice.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.TypedModel;
 import com.liferay.portal.kernel.service.SystemEventLocalServiceUtil;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
+import com.liferay.portal.kernel.systemevent.SystemEventDynamicVariable;
 import com.liferay.portal.kernel.systemevent.SystemEventHierarchyEntry;
 import com.liferay.portal.kernel.systemevent.SystemEventHierarchyEntryThreadLocal;
 import com.liferay.portal.kernel.util.StringBundler;
@@ -47,6 +48,10 @@ public class SystemEventAdvice
 	@Override
 	public void afterReturning(MethodInvocation methodInvocation, Object result)
 		throws Throwable {
+
+		if (!SystemEventDynamicVariable.ENABLED.getValue()) {
+			return;
+		}
 
 		SystemEvent systemEvent = findAnnotation(methodInvocation);
 
@@ -113,6 +118,10 @@ public class SystemEventAdvice
 
 	@Override
 	public Object before(MethodInvocation methodInvocation) throws Throwable {
+		if (!SystemEventDynamicVariable.ENABLED.getValue()) {
+			return null;
+		}
+
 		SystemEvent systemEvent = findAnnotation(methodInvocation);
 
 		if (systemEvent == _nullSystemEvent) {

--- a/portal-kernel/src/com/liferay/portal/kernel/systemevent/SystemEventDynamicVariable.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/systemevent/SystemEventDynamicVariable.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.systemevent;
+
+import com.liferay.portal.kernel.util.AutoResetThreadLocalDynamicVariable;
+import com.liferay.portal.kernel.util.DynamicVariable;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class SystemEventDynamicVariable {
+
+	public static final DynamicVariable<Boolean> ENABLED =
+		new AutoResetThreadLocalDynamicVariable<>(() -> true);
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/systemevent/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/systemevent/packageinfo
@@ -1,1 +1,1 @@
-version 6.2.0
+version 6.3.0

--- a/portal-kernel/src/com/liferay/portal/kernel/util/AutoResetThreadLocalDynamicVariable.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/AutoResetThreadLocalDynamicVariable.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.util;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class AutoResetThreadLocalDynamicVariable<T>
+	implements DynamicVariable<T> {
+
+	public AutoResetThreadLocalDynamicVariable(
+		java.util.function.Supplier<T> supplier) {
+
+		_threadLocal = new AutoResetThreadLocal<>(null, supplier);
+	}
+
+	@Override
+	public T getValue() {
+		return _threadLocal.get();
+	}
+
+	@Override
+	public <S, E extends Exception> S withValue(
+			T value, CheckedCallable<S, E> callable)
+		throws E {
+
+		T oldValue = _threadLocal.get();
+
+		try {
+			_threadLocal.set(value);
+
+			return callable.call();
+		}
+		finally {
+			_threadLocal.set(oldValue);
+		}
+	}
+
+	@Override
+	public <E extends Exception> void withValue(
+			T value, CheckedRunnable<E> runnable)
+		throws E {
+
+		T oldValue = _threadLocal.get();
+
+		try {
+			_threadLocal.set(value);
+
+			runnable.run();
+		}
+		finally {
+			_threadLocal.set(oldValue);
+		}
+	}
+
+	private final AutoResetThreadLocal<T> _threadLocal;
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/util/CheckedCallable.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/CheckedCallable.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.util;
+
+/**
+ * @author Adolfo Pérez
+ */
+@FunctionalInterface
+public interface CheckedCallable<T, E extends Exception> {
+
+	public T call() throws E;
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/util/CheckedRunnable.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/CheckedRunnable.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.util;
+
+/**
+ * @author Adolfo Pérez
+ */
+@FunctionalInterface
+public interface CheckedRunnable<E extends Exception> {
+
+	public void run() throws E;
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/util/DynamicVariable.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/DynamicVariable.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.util;
+
+/**
+ * @author Adolfo Pérez
+ */
+public interface DynamicVariable<T> {
+
+	public T getValue();
+
+	public <S, E extends Exception> S withValue(
+			T value, CheckedCallable<S, E> callable)
+		throws E;
+
+	public <E extends Exception> void withValue(
+			T value, CheckedRunnable<E> runnable)
+		throws E;
+
+}


### PR DESCRIPTION
Hey @matethurzo,

This is one of the possible solutions to the SystemEvent issue. This
could also be solved at the D&M level using the same approach, but I
think this belongs to the SystemEvent API for a couple of reasons:

- Although direct calls to the SystemEvent service can be made to
  customize event generation (as Journal does), in the majority of the
  cases the main entry point is the annotation. As the annotation
  is too restrictive, IMO the API needs a convenient way to enable
  disable system events.

- In the case of D&M, an approach like the one used in Journal is not
  possible, as we cannot make the decission about whether to create
  events or not at the DLFileEntry service level, and we cannot move
  the annotation up in the call hierarchy, as that would break other
  cases.

- There are at least two cases where something like this is
  necessary/desirable (D&M and Journal), so it seems sensible to
  include this mechanism as part of the API.

Also note that the whole `DynamicVariable` business is not strictly
necessary; this could be implemented in a more traditional way
following the `FooThreadLocalUtil` pattern. I did it this way because
I want to show this to Brian and get rid of the old pattern (I
explained some of the reasons in the commit messages).

Thanks!