### PR TITLE
[TECHNICAL-SUPPORT] LPS-73526

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -1647,6 +1647,8 @@ public class PropsValues {
 
 	public static final boolean TUNNELING_SERVLET_SHARED_SECRET_HEX = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.TUNNELING_SERVLET_SHARED_SECRET_HEX));
 
+	public static final String TUNNELING_SERVLET_TIMEOUT = PropsUtil.get(PropsKeys.TUNNELING_SERVLET_TIMEOUT);
+
 	public static final boolean UPGRADE_DATABASE_TRANSACTIONS_DISABLED = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.UPGRADE_DATABASE_TRANSACTIONS_DISABLED));
 
 	/**

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -5718,6 +5718,13 @@
     #
     #tunneling.servlet.shared.secret.hex=true
 
+    #
+    # Set this timeout to enforce a connection timeout for connections between
+    # servers via the tunneling servlet. Without setting this value, the actual
+    # timeout enforced may vary between environments.
+    #
+    # tunneling.servlet.timeout=
+
 ##
 ## ImageMagick
 ##

--- a/portal-kernel/src/com/liferay/portal/kernel/service/http/TunnelUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/http/TunnelUtil.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.MethodHandler;
 import com.liferay.portal.kernel.util.ObjectValuePair;
+import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.ProtectedClassLoaderObjectInputStream;
 
@@ -124,6 +125,13 @@ public class TunnelUtil {
 			HttpHeaders.CONTENT_TYPE,
 			ContentTypes.APPLICATION_X_JAVA_SERIALIZED_OBJECT);
 		httpURLConnection.setUseCaches(false);
+
+		int connectTimeout = GetterUtil.getInteger(
+			PropsUtil.get(PropsKeys.TUNNELING_SERVLET_TIMEOUT));
+
+		if (connectTimeout > 0) {
+			httpURLConnection.setConnectTimeout(connectTimeout);
+		}
 
 		httpURLConnection.setRequestMethod(HttpMethods.POST);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -2350,6 +2350,8 @@ public interface PropsKeys {
 
 	public static final String TUNNELING_SERVLET_SHARED_SECRET_HEX = "tunneling.servlet.shared.secret.hex";
 
+	public static final String TUNNELING_SERVLET_TIMEOUT = "tunneling.servlet.timeout";
+
 	public static final String UPGRADE_DATABASE_TRANSACTIONS_DISABLED = "upgrade.database.transactions.disabled";
 
 	public static final String UPGRADE_PROCESSES = "upgrade.processes";


### PR DESCRIPTION
Relevant tickets:

https://issues.liferay.com/browse/LPS-73526
https://issues.liferay.com/browse/LPP-25980

Sending this directly to you because the normal TSE reviewers are out of the office.

The client is experiencing an issue where a platform-dependent timeout for accessing the remote live server with remote staging is causing their staging server to become unusable when the live server is down (their timeout is long enough that it triggers their proxy server's timeout, so they can't load pages).

The problem is only for admins and not guest users, because guest users viewing a public staging site do not trigger any access to the remote live site (whereas admins have two buttons that access it -- "Go to Remote Live" and "Remote Live" -- meaning the platform-dependent timeout length is reached twice before the page loads).

I think the easiest way to solve it (and least likely way to introduce regressions/behavior changes for other clients on DXP) is to introduce a new portal property that adds the option to introduce this timeout. That way we don't have to commit to a default value necessarily, but instead recommend a reasonable value be set for if and when the remote server goes down. I've tested this using an EC2 instance that experiences the long timeouts.

Please let me know if there are any concerns or alternative suggestions. Thank you.