### PR TITLE
LPS-74083

### DIFF
--- a/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/content/processor/base/BaseTextExportImportContentProcessor.java
+++ b/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/content/processor/base/BaseTextExportImportContentProcessor.java
@@ -714,7 +714,12 @@ public class BaseTextExportImportContentProcessor
 					throw new NoSuchLayoutException();
 				}
 
-				urlSB.append(DATA_HANDLER_GROUP_FRIENDLY_URL);
+				if (urlGroup.getGroupId() == groupId) {
+					urlSB.append(DATA_HANDLER_GROUP_FRIENDLY_URL);
+				}
+				else {
+					urlSB.append(groupFriendlyURL);
+				}
 
 				String siteAdminURL =
 					GroupConstants.CONTROL_PANEL_FRIENDLY_URL +

--- a/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/content/processor/DefaultTextExportImportContentProcessor.java
+++ b/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/content/processor/DefaultTextExportImportContentProcessor.java
@@ -702,7 +702,12 @@ public class DefaultTextExportImportContentProcessor
 					throw new NoSuchLayoutException();
 				}
 
-				urlSB.append(_DATA_HANDLER_GROUP_FRIENDLY_URL);
+				if (urlGroup.getGroupId() == groupId) {
+					urlSB.append(_DATA_HANDLER_GROUP_FRIENDLY_URL);
+				}
+				else {
+					urlSB.append(groupFriendlyURL);
+				}
 
 				String siteAdminURL =
 					GroupConstants.CONTROL_PANEL_FRIENDLY_URL +

--- a/modules/apps/web-experience/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/DefaultExportImportContentProcessorTest.java
+++ b/modules/apps/web-experience/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/DefaultExportImportContentProcessorTest.java
@@ -352,7 +352,7 @@ public class DefaultExportImportContentProcessorTest {
 
 		Assert.assertFalse(
 			content.contains(VirtualLayoutConstants.CANONICAL_URL_SEPARATOR));
-		Assert.assertFalse(
+		Assert.assertTrue(
 			content.contains(GroupConstants.CONTROL_PANEL_FRIENDLY_URL));
 		Assert.assertFalse(
 			content.contains(PropsValues.CONTROL_PANEL_LAYOUT_FRIENDLY_URL));
@@ -409,7 +409,7 @@ public class DefaultExportImportContentProcessorTest {
 
 		Assert.assertFalse(
 			content.contains(VirtualLayoutConstants.CANONICAL_URL_SEPARATOR));
-		Assert.assertFalse(
+		Assert.assertTrue(
 			content.contains(GroupConstants.CONTROL_PANEL_FRIENDLY_URL));
 		Assert.assertFalse(
 			content.contains(PropsValues.CONTROL_PANEL_LAYOUT_FRIENDLY_URL));


### PR DESCRIPTION
Hi @matethurzo,

Please review this fix from @yuhai.

I am not sure what the intended behavior is in the case that you are exporting/importing a web content with a link to a page on the same site as the web content. As I see it, there could be two possibilities for the intended behavior:

1. The behavior in this fix, where if the link is a link of the same site it is exported from, we assume that the imported link should go to the site that you linked to.
2. The link is treated as an absolute link, and will always link to the site that it originally linked to when it was exported.

I am not sure which of these cases is the intended behavior, and I think an argument could be made for either one. Perhaps the (1) behavior could be used as the default, and then the (2) behavior could be used if we determine that (1) behavior would lead to an invalid link on importing? Let me know what you think.