### PR TITLE
[TS] LPS-75041

### DIFF
--- a/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
+++ b/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
@@ -1524,33 +1524,16 @@ public class ServicePreAction extends Action {
 			return new LayoutComposite(layout, layouts);
 		}
 
-		Group group = layout.getGroup();
-
-		boolean hasViewLayoutPermission = false;
-		boolean hasViewStagingPermission =
-			(group.isStagingGroup() || group.isStagedRemotely()) &&
-			 !group.isControlPanel() &&
-			 GroupPermissionUtil.contains(
-				 permissionChecker, group, ActionKeys.VIEW_STAGING);
-
-		if (hasAccessPermission(
-				permissionChecker, layout, doAsGroupId, false) ||
-			hasViewStagingPermission) {
-
-			hasViewLayoutPermission = true;
-		}
-
 		List<Layout> accessibleLayouts = new ArrayList<>();
 
 		for (int i = 0; i < layouts.size(); i++) {
 			Layout curLayout = layouts.get(i);
 
 			if (!curLayout.isHidden() &&
-				(hasAccessPermission(
-					permissionChecker, curLayout, doAsGroupId, false) ||
-				 hasViewStagingPermission)) {
+				hasAccessPermission(
+					permissionChecker, curLayout, doAsGroupId, false)) {
 
-				if (accessibleLayouts.isEmpty() && !hasViewLayoutPermission) {
+				if (accessibleLayouts.isEmpty()) {
 					layout = curLayout;
 				}
 
@@ -1561,7 +1544,7 @@ public class ServicePreAction extends Action {
 		if (accessibleLayouts.isEmpty()) {
 			layouts = null;
 
-			if (!isLoginRequest(request) && !hasViewLayoutPermission) {
+			if (!isLoginRequest(request)) {
 				if (user.isDefaultUser() &&
 					PropsValues.AUTH_LOGIN_PROMPT_ENABLED) {
 


### PR DESCRIPTION
cc @hhuijser, 

Hi @matethurzo,

The root issue: If the user owns "View Staging" permission, the user can access to staging page (we remove staging page "view" permission, the user shouldn't access.)

Please refer to https://github.com/yuhai/liferay-portal/blob/master/portal-kernel/src/com/liferay/portal/kernel/theme/NavItem.java#L97, navigation will be replaced by themeDisplay.getLayouts(); And themeDisplay.setLayouts(layouts) is in https://github.com/yuhai/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/events/ServicePreAction.java#L769

The commit "LPS-6432 Divide Manage Pages into atomic actions / Fix Power User role" added that the user with "view staging" permission can access to those staging page (the user doesn't own "view" permission for this staging page).

When the user owns "View Staging" permission, it shouldn't mean the user can view staging pages. For one staging page, if we remove "view" permission for the user, the user shouldn't access to this page even though the user owns "View Staging" permission.

Regards,
Hai