### PR TITLE
LPS-74465 References are selected for the not selected contents at editing publish templates

### DIFF
--- a/modules/apps/web-experience/staging/staging-processes-web/src/main/resources/META-INF/resources/js/main.js
+++ b/modules/apps/web-experience/staging/staging-processes-web/src/main/resources/META-INF/resources/js/main.js
@@ -890,11 +890,22 @@ AUI.add(
 
 						var inputs = contentNode.all('.field');
 
+						var portletDataNode = instance.byId('PORTLET_DATA_' + portletId);
+
+						var portletChecked = portletDataNode.attr('checked');
+
 						var selectedContent = [];
 
 						inputs.each(
 							function(item, index, collection) {
-								var checked = item.attr(STR_CHECKED);
+								var checked = false;
+
+								if (portletChecked) {
+									checked = item.attr(STR_CHECKED);
+								}
+								else {
+									item.attr(STR_CHECKED, false);
+								}
 
 								if (checked) {
 									selectedContent.push(item.attr('data-name'));
@@ -903,7 +914,7 @@ AUI.add(
 						);
 
 						if (selectedContent.length === 0) {
-							instance.byId('PORTLET_DATA_' + portletId).attr('checked', false);
+							portletDataNode.attr('checked', false);
 
 							instance.byId('showChangeContent_' + portletId).hide();
 						}


### PR DESCRIPTION
Hi Máté,

There is a similar issue with export template. I opened a ticket for that but I have no time to fix that (same code in other module would fix that). I wanted to create a new module for the common js code to eliminate js-code duplication, but I have no time for that. I will work on the new module after my holiday.

Thank you
Péter