### PR TITLE
LPS-71031 The result of history deletion is not visible until the page is refreshed

### DIFF
--- a/modules/apps/web-experience/staging/staging-bar-web/src/main/resources/META-INF/resources/js/staging_version.js
+++ b/modules/apps/web-experience/staging/staging-bar-web/src/main/resources/META-INF/resources/js/staging_version.js
@@ -156,6 +156,11 @@ AUI.add(
 					Liferay.Util.openWindow(
 						{
 							dialog: {
+								after: {
+									destroy: function(event) {
+										window.location.reload();
+									}
+								},
 								destroyOnHide: true
 							},
 							title: Liferay.Language.get('history'),


### PR DESCRIPTION
Hi Máté,

The same old page-refresh-after-closing-the-popup trick solves this.

Thank you in advance
Péter