### PR TITLE
LPS-76111 Publishing will fail if the linked document is in the Recycle Bin.

### DIFF
--- a/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/content/processor/DefaultTextExportImportContentProcessor.java
+++ b/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/content/processor/DefaultTextExportImportContentProcessor.java
@@ -409,7 +409,14 @@ public class DefaultTextExportImportContentProcessor
 
 				sb.replace(beginPos, endPos, exportedReferenceSB.toString());
 
-				deleteTimestampParameters(sb, beginPos);
+				int deleteTimestampParametersOffset = beginPos;
+
+				if (fileEntry.isInTrash()) {
+					deleteTimestampParametersOffset = sb.indexOf(
+						"[#dl-reference=", beginPos);
+				}
+
+				deleteTimestampParameters(sb, deleteTimestampParametersOffset);
 			}
 			catch (Exception e) {
 				if (_log.isDebugEnabled()) {

--- a/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/content/processor/DefaultTextExportImportContentProcessor.java
+++ b/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/content/processor/DefaultTextExportImportContentProcessor.java
@@ -400,9 +400,7 @@ public class DefaultTextExportImportContentProcessor
 				exportedReferenceSB.append("$]");
 
 				if (fileEntry.isInTrash()) {
-					String originalReference = DLUtil.getPreviewURL(
-						fileEntry, fileEntry.getFileVersion(), null,
-						StringPool.BLANK, false, false);
+					String originalReference = sb.substring(beginPos, endPos);
 
 					exportedReferenceSB.append("[#dl-reference=");
 					exportedReferenceSB.append(originalReference);

--- a/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/content/processor/DefaultTextExportImportContentProcessor.java
+++ b/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/content/processor/DefaultTextExportImportContentProcessor.java
@@ -368,7 +368,7 @@ public class DefaultTextExportImportContentProcessor
 			endPos = MapUtil.getInteger(dlReferenceParameters, "endPos");
 
 			try {
-				if (exportReferencedContent) {
+				if (exportReferencedContent && !fileEntry.isInTrash()) {
 					StagedModelDataHandlerUtil.exportReferenceStagedModel(
 						portletDataContext, stagedModel, fileEntry,
 						PortletDataContext.REFERENCE_TYPE_DEPENDENCY);
@@ -377,9 +377,18 @@ public class DefaultTextExportImportContentProcessor
 					Element entityElement =
 						portletDataContext.getExportDataElement(stagedModel);
 
+					String referenceType =
+						PortletDataContext.REFERENCE_TYPE_DEPENDENCY;
+
+					if (fileEntry.isInTrash()) {
+						referenceType =
+							PortletDataContext.
+								REFERENCE_TYPE_DEPENDENCY_DISPOSABLE;
+					}
+
 					portletDataContext.addReferenceElement(
-						stagedModel, entityElement, fileEntry,
-						PortletDataContext.REFERENCE_TYPE_DEPENDENCY, true);
+						stagedModel, entityElement, fileEntry, referenceType,
+						true);
 				}
 
 				String path = ExportImportPathUtil.getModelPath(fileEntry);

--- a/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/content/processor/DefaultTextExportImportContentProcessor.java
+++ b/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/content/processor/DefaultTextExportImportContentProcessor.java
@@ -1013,9 +1013,8 @@ public class DefaultTextExportImportContentProcessor
 					String exportedReference = content.substring(
 						beginPos, postfixPos + 2);
 
-					content = StringUtil.replaceFirst(
-						content, exportedReference, originalReference,
-						beginPos);
+					content = StringUtil.replace(
+						content, exportedReference, originalReference);
 				}
 
 				continue;
@@ -1029,20 +1028,15 @@ public class DefaultTextExportImportContentProcessor
 				content = StringUtil.replace(content, "$]?", "$]&");
 			}
 
+			String exportedReference = "[$dl-reference=" + path + "$]";
+
 			if (content.startsWith("[#dl-reference=", endPos)) {
-				int prefixPos = endPos;
+				endPos = content.indexOf("#]", beginPos) + 2;
 
-				int postfixPos = content.indexOf("#]", prefixPos);
-
-				String redundantDLURL = content.substring(
-					prefixPos, postfixPos + 2);
-
-				content = StringUtil.replaceFirst(
-					content, redundantDLURL, StringPool.BLANK, beginPos);
+				exportedReference = content.substring(beginPos, endPos);
 			}
 
-			content = StringUtil.replaceFirst(
-				content, "[$dl-reference=" + path + "$]", url, beginPos);
+			content = StringUtil.replace(content, exportedReference, url);
 		}
 
 		return content;


### PR DESCRIPTION
Hey Máté,

this fix is about a special use case, when the referenced document is in the Trash during the export.

In this case, instead of trying to export it or creating a DEPENDENCY typed reference, a DISPOSABLE typed reference will be created.
This gives us the flexibility, as we don't know during export if the document exists at the import side or not.

The original reference is also appended to the exported content, so if the document is missing, we can replace it back.

Could you please review it?

Thanks,
Tamás