### PR TITLE
LPS-74521 missing in-browser validation for site template name and portlet export file name

### DIFF
--- a/modules/apps/web-experience/export-import/export-import-web/src/main/resources/META-INF/resources/export/init.jsp
+++ b/modules/apps/web-experience/export-import/export-import-web/src/main/resources/META-INF/resources/export/init.jsp
@@ -14,4 +14,10 @@
  */
 --%>
 
+<%@ page import="com.liferay.portal.kernel.json.JSONArray" %><%@
+page import="com.liferay.portal.kernel.json.JSONFactoryUtil" %><%@
+page import="com.liferay.portal.util.PropsValues" %>
+
+<%@ page import="java.util.Arrays" %>
+
 <%@ include file="/init.jsp" %>

--- a/modules/apps/web-experience/export-import/export-import-web/src/main/resources/META-INF/resources/export/new_export/export_layouts.jsp
+++ b/modules/apps/web-experience/export-import/export-import-web/src/main/resources/META-INF/resources/export/new_export/export_layouts.jsp
@@ -80,6 +80,12 @@ portletDisplay.setShowBackIcon(true);
 portletDisplay.setURLBack(portletURL.toString());
 
 renderResponse.setTitle(!configuredExport ? LanguageUtil.get(request, "new-custom-export") : LanguageUtil.format(request, "new-export-based-on-x", exportImportConfiguration.getName(), false));
+
+JSONArray blacklistedCharacters = JSONFactoryUtil.createJSONArray();
+
+for (String s : PropsValues.DL_CHAR_BLACKLIST) {
+	blacklistedCharacters.put(s);
+}
 %>
 
 <div class="container-fluid-1280">
@@ -180,7 +186,9 @@ renderResponse.setTitle(!configuredExport ? LanguageUtil.get(request, "new-custo
 
 	Liferay.component('<portlet:namespace />ExportImportComponent', exportImport);
 
-	var form = A.one('#<portlet:namespace />fm1');
+	var liferayForm = Liferay.Form.get('<portlet:namespace />fm1');
+
+	var form = liferayForm.formNode;
 
 	form.on(
 		'submit',
@@ -199,6 +207,35 @@ renderResponse.setTitle(!configuredExport ? LanguageUtil.get(request, "new-custo
 			}
 		}
 	);
+
+	var oldFieldRules = liferayForm.get('fieldRules');
+
+	var fieldRules = [
+		{
+			body: function(val, fieldNode, ruleValue) {
+				var blacklistedCharacters = <%= blacklistedCharacters.toJSONString() %>;
+
+				for (var i = 0; i < blacklistedCharacters.length; i++) {
+					if (val.indexOf(blacklistedCharacters[i]) !== -1) {
+						return false;
+					}
+				};
+
+				return true;
+			},
+			custom: true,
+			errorMessage: '<%= LanguageUtil.get(request, "the-following-are-invalid-characters") + HtmlUtil.escapeJS(Arrays.toString(PropsValues.DL_CHAR_BLACKLIST)) %>',
+			fieldName: '<portlet:namespace />name',
+			validatorName: 'custom_pageTemplateNameValidator'
+		}
+	];
+
+	if (oldFieldRules) {
+		fieldRules = fieldRules.concat(oldFieldRules);
+	}
+
+	liferayForm.set('fieldRules', fieldRules);
+
 </aui:script>
 
 <aui:script>

--- a/modules/apps/web-experience/export-import/export-import-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/web-experience/export-import/export-import-web/src/main/resources/META-INF/resources/init.jsp
@@ -155,6 +155,7 @@ page import="com.liferay.taglib.search.ResultRow" %>
 page import="java.text.Format" %>
 
 <%@ page import="java.util.ArrayList" %><%@
+page import="java.util.Arrays" %><%@
 page import="java.util.Calendar" %><%@
 page import="java.util.Collections" %><%@
 page import="java.util.Date" %><%@


### PR DESCRIPTION
Hi Máté,

lar file names generated based on title when exporting layouts. If user types special characters like ":" "*" the backend rejects it, so in-browser validation is required.

This ticket comes from support, waited in your queue for a while. You were not satisfied with the solution and passed it to me. I completely re-wrote the code and sent back to support for checking. They had no time, then had issues applying the pattern for portlet export file name, so I did that.

The pattern came from here:
https://dev.liferay.com/develop/tutorials/-/knowledge_base/7-0/forms-and-validation#adding-custom-validators-in-javascript

I tried to test it, but it did not finished after 14 hours.
https://github.com/peterborkuti/liferay-portal/pull/49

QA has no time for pre-testing and the impact of the fix is low. The first part was tested by David and support.

Thanks
Péter