### PR TITLE
[Technical Support] LPS-78293 Disabled and checked checkboxes are not being passed as parameters in 'Refresh Count'

### DIFF
--- a/modules/apps/web-experience/export-import/export-import-web/src/main/resources/META-INF/resources/js/main.js
+++ b/modules/apps/web-experience/export-import/export-import-web/src/main/resources/META-INF/resources/js/main.js
@@ -873,13 +873,19 @@ AUI.add(
 						}
 
 						if (cmdNode) {
-							var currentURL = instance.byId('currentURL');
+							var form = instance.get('form');
 
+							var portletURL = Liferay.PortletURL.createURL(form.get('action'));
+
+							instance._setDisabledCheckboxParameters(portletURL);
+							form.set('action', portletURL.toString());
+
+							var currentURL = instance.byId('currentURL');
 							redirectNode.val(currentURL);
 
 							cmdNode.val(STR_EMPTY);
 
-							submitForm(instance.get('form'));
+							submitForm(form);
 						}
 					},
 
@@ -1073,6 +1079,40 @@ AUI.add(
 						}
 
 						instance._setLabels('contentOptionsLink', 'selectedContentOptions', selectedContentOptions.join(', '));
+					},
+
+					_setDisabledCheckboxParameters: function(portletURL) {
+						var instance = this;
+
+						$('[id^=' + instance.ns('PORTLET_DATA') + ']').each(
+							function() {
+								var input = $(this);
+
+								if (input.is(':checkbox')) {
+									var id = input.prop('id');
+
+									var controlCheckboxes = $('[data-root-control-id=' + id + ']');
+
+									if (controlCheckboxes.length == 0) {
+										return;
+									}
+
+									controlCheckboxes.each(
+										function() {
+											var controlCheckbox = $(this);
+
+											if (controlCheckbox.is(':disabled') && controlCheckbox.is(':checked')) {
+												var controlCheckboxName = controlCheckbox.prop('name');
+
+												controlCheckboxName = controlCheckboxName.replace(instance.NS, '');
+
+												portletURL.setParameter(controlCheckboxName, 'true');
+											}
+										}
+									);
+								}
+							}
+						);
 					},
 
 					_setGlobalConfigurationLabels: function() {


### PR DESCRIPTION
Related tickets:
https://issues.liferay.com/browse/LPS-78293

When we enter the Export/Import modal for ADTs, the contents, in the corresponding fieldset, only consist of "Application Display Templates". The checkbox for this content is both checked and disabled, so when we try to "Refresh Count", the request goes to the backend without this parameter, which is interpreted as false by the backend. 
This started to happen during the implementation of DXP when all hidden inputs associated with checkboxes were removed (see [LPS-44228](https://issues.liferay.com/browse/LPS-44228)).
Also, if you need some more context, there's the [LPS-68460](https://issues.liferay.com/browse/LPS-68460) that detected the same problem in Message Boards but chose to fix it locally.
Any questions you might have about this, don't hesitate to ask. I'll be happy to help.

Many thanks in advance.