### PR TITLE
LPS-78466 Broken hyperlinks in basic webcontent after import

### DIFF
--- a/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/content/processor/LayoutReferencesExportImportContentProcessor.java
+++ b/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/content/processor/LayoutReferencesExportImportContentProcessor.java
@@ -437,7 +437,7 @@ public class LayoutReferencesExportImportContentProcessor
 
 					urlSB.append(liveGroup.getUuid());
 				}
-				else if (group.getGroupId() == urlGroup.getGroupId()) {
+				else if (!urlGroup.isControlPanel()) {
 					urlSB.append(urlGroup.getFriendlyURL());
 				}
 				else {
@@ -620,9 +620,13 @@ public class LayoutReferencesExportImportContentProcessor
 				_groupLocalService.fetchGroupByUuidAndCompanyId(
 					groupUuid, portletDataContext.getCompanyId());
 
-			if ((groupFriendlyUrlGroup == null) ||
-				groupUuid.startsWith(StringPool.SLASH)) {
+			if (groupFriendlyUrlGroup == null) {
+				groupFriendlyUrlGroup =
+					_groupLocalService.fetchFriendlyURLGroup(
+						portletDataContext.getCompanyId(), groupUuid);
+			}
 
+			if (groupFriendlyUrlGroup == null) {
 				content = StringUtil.replaceFirst(
 					content, _DATA_HANDLER_GROUP_FRIENDLY_URL,
 					group.getFriendlyURL(), groupFriendlyUrlPos);


### PR DESCRIPTION
Hey Máté,

before this fix if we had a link from a different group, we appended the group's UUID.
This works fine while staging is enabled, but causes problems when we export/import the Sites, as the UUIDs won't match between the export and the import sides.

My idea was to use the group's friendly URL instead.
Vendel made sure that the new import logic will handle the previously created LAR files as well by fetching the group by the UUID first (which is needed for staging as well).

Thanks
Tamás