### PR TITLE
LPS-80841 - use friendly URL if group is external

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/content/processor/LayoutReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/content/processor/LayoutReferencesExportImportContentProcessor.java
@@ -441,7 +441,8 @@ public class LayoutReferencesExportImportContentProcessor
 					urlSB.append(liveGroup.getUuid());
 				}
 				else if (urlGroup.isControlPanel() ||
-						 _stagingGroupHelper.isLiveGroup(urlGroup)) {
+						 (_stagingGroupHelper.isLiveGroup(urlGroup) &&
+						  (group.getLiveGroupId() == urlGroup.getGroupId()))) {
 
 					urlSB.append(urlGroup.getUuid());
 				}


### PR DESCRIPTION
CC @jonathanmccann

Sending straight to you as per Jonathan's request.

From Lianne:

> LPP: https://issues.liferay.com/browse/LPP-29923
> LPS: https://issues.liferay.com/browse/LPS-80841
> 
> The issue is that site names in URLs are being changed to the publishing site. Per LPS-78466 (50bee79), we must use the Friendly URL for external groups. The fix checks if the group is the same before using the UUID. Please let me know if you have any questions or concerns.