### PR TITLE
LPS-81083 Retrieve layoutRevision based on layoutSetBranchId

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/StagingImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/StagingImpl.java
@@ -110,6 +110,7 @@ import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalService;
 import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
+import com.liferay.portal.kernel.service.persistence.LayoutRevisionUtil;
 import com.liferay.portal.kernel.servlet.ServletResponseConstants;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.upload.UploadRequestSizeException;
@@ -3352,10 +3353,13 @@ public class StagingImpl implements Staging {
 		throws PortalException {
 
 		if (ExportImportThreadLocal.isLayoutStagingInProcess()) {
-			LayoutRevision layoutRevision =
-				_layoutRevisionLocalService.fetchLastLayoutRevision(plid, true);
+			List<LayoutRevision> layoutRevisions =
+				LayoutRevisionUtil.findByL_H_P_Collection(
+					layoutSetBranchId, true, plid, 0, 1);
 
-			if (layoutRevision != null) {
+			if (layoutRevisions != null) {
+				LayoutRevision layoutRevision = layoutRevisions.get(0);
+
 				return layoutRevision.getLayoutRevisionId();
 			}
 			else {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-81083
@SamZiemer @jonathanmccann

Hello Mate,
I fixed the issue that was still present after https://issues.liferay.com/browse/LPS-78292 where layout revisions of other layout set branches (Site Page Variations) would be published. This resolves all the issues I have found related to publishing the incorrect content.

LayoutRevisionUtil.findByL_H_P_Collection() should always return at most 1 result when head = true as there's only one head LayoutRevision per layoutSetBranch. 