### PR TITLE
[TECHNICAL-SUPPORT] LPS-81464

### DIFF
--- a/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/remote_options/page.jsp
+++ b/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/remote_options/page.jsp
@@ -28,7 +28,7 @@
 
 		<aui:input disabled="<%= disableInputs %>" label="remote-path-context" name="remotePathContext" size="10" type="text" value='<%= MapUtil.getString(settingsMap, "remotePathContext", liveGroupTypeSettings.getProperty("remotePathContext")) %>' />
 
-		<aui:input disabled="<%= disableInputs %>" label="remote-site-id" name="remoteGroupId" size="10" type="text" value='<%= MapUtil.getString(settingsMap, "remoteGroupId", liveGroupTypeSettings.getProperty("remoteGroupId")) %>' />
+		<aui:input disabled="<%= disableInputs %>" label="remote-site-id" name="remoteGroupId" size="10" type="text" value='<%= MapUtil.getString(settingsMap, "targetGroupId", liveGroupTypeSettings.getProperty("remoteGroupId")) %>' />
 
 		<aui:input disabled="<%= disableInputs %>" name="remotePrivateLayout" type="hidden" value='<%= MapUtil.getBoolean(settingsMap, "remotePrivateLayout", privateLayout) %>' />
 	</aui:fieldset>


### PR DESCRIPTION
From @wanderlast:

> The issue is that, in remote publishing templates, the siteID would previously always get autofilled with whatever site was set as the live site during initial staging setup. This is due to the code trying to pull a non-existent setting from the settingsmap and therefore defaulting to that site. The fix sets the code to pull from the correct name in the settingsmap.