### PR TITLE
[TECHNICAL-SUPPORT] LPS-81981

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/StagingImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/StagingImpl.java
@@ -2682,6 +2682,8 @@ public class StagingImpl implements Staging {
 					publishLayoutRemoteSettingsMap, "secureConnection");
 				remotePrivateLayout = MapUtil.getBoolean(
 					publishLayoutRemoteSettingsMap, "remotePrivateLayout");
+				remoteGroupId = MapUtil.getLong(
+					publishLayoutRemoteSettingsMap, "targetGroupId");
 
 				if (!Validator.isBlank(name)) {
 					Map<String, String[]> parameterMap =
@@ -2866,6 +2868,11 @@ public class StagingImpl implements Staging {
 		boolean secureConnection = false;
 		boolean remotePrivateLayout = false;
 
+		long remoteGroupId = ParamUtil.getLong(
+			portletRequest, "remoteGroupId",
+			GetterUtil.getLong(
+				groupTypeSettingsProperties.getProperty("remoteGroupId")));
+
 		long exportImportConfigurationId = ParamUtil.getLong(
 			portletRequest, "exportImportConfigurationId");
 
@@ -2888,6 +2895,7 @@ public class StagingImpl implements Staging {
 				remotePort = MapUtil.getInteger(settingsMap, "remotePort");
 				remotePathContext = MapUtil.getString(
 					settingsMap, "remotePathContext");
+				remoteGroupId = MapUtil.getLong(settingsMap, "targetGroupId");
 				secureConnection = MapUtil.getBoolean(
 					settingsMap, "secureConnection");
 				remotePrivateLayout = MapUtil.getBoolean(
@@ -2921,10 +2929,6 @@ public class StagingImpl implements Staging {
 		}
 
 		remoteAddress = stripProtocolFromRemoteAddress(remoteAddress);
-		long remoteGroupId = ParamUtil.getLong(
-			portletRequest, "remoteGroupId",
-			GetterUtil.getLong(
-				groupTypeSettingsProperties.getProperty("remoteGroupId")));
 
 		_groupLocalService.validateRemote(
 			groupId, remoteAddress, remotePort, remotePathContext,


### PR DESCRIPTION
From @wanderlast:

> LPS: https://issues.liferay.com/browse/LPS-81981
> LPP: https://issues.liferay.com/browse/LPP-30210 (the relevant breakdown of this issue is here though)
> 
> This issue is focused on remote staging over three separate instances--specifically trying to publish to a third instance/site that is not a part of the initial staging/remote live pair. In the current code, we get the remoteGroupID from our typeSettings which is the value saved when staging is first setup. Therefore this remoteGroupID is always equivalent to the initial remote live groupID even if our publication is setup to publish to another site. This causes issues for two reasons:
> 
> 1. The remoteGroupID isn't necessarily the one we're publishing to, so verifying it exists is pointless.
> 2. The remoteGroupID may not exist on the portal instance that we're publishing to, even if the site we wish to publish does, causing an exception and causing the publish attempt to fail.
> The code currently checks for a specific configuration and grabs all other remote options from that configuration (e.g. the port, connection path, etc). The fix therefore changes the remoteGroupID to the targetGroupID from that configuration if it exists since it is equivalent to the site we actually will publish to.
> 
> Please let me know if you have any questions. Thanks! 