### PR TITLE
LPS-81940 Asset publisher in Live has different order configuration

### DIFF
--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalService.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalService.java
@@ -3554,4 +3554,22 @@ public interface JournalArticleLocalService extends BaseLocalService,
 	@Deprecated
 	public void updateTemplateId(long groupId, long classNameId,
 		String oldDDMTemplateKey, String newDDMTemplateKey);
+
+	/**
+	* Updates the URL title of the web content article.
+	*
+	* @param article the web content article
+	* @param urlTitle the web content article's URL title
+	* @param serviceContext the service context to be applied. Can set the
+	modification date, status date, and portlet preferences. With
+	respect to social activities, by setting the service context's
+	command to {@link Constants#UPDATE}, the invocation is considered
+	a web content update activity; otherwise it is considered a web
+	content add activity.
+	* @return the updated web content article
+	*/
+	@Indexable(type = IndexableType.REINDEX)
+	public JournalArticle updateUrlTitle(JournalArticle article,
+		String urlTitle, ServiceContext serviceContext)
+		throws PortalException;
 }

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalServiceUtil.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalServiceUtil.java
@@ -4082,6 +4082,26 @@ public class JournalArticleLocalServiceUtil {
 			newDDMTemplateKey);
 	}
 
+	/**
+	* Updates the URL title of the web content article.
+	*
+	* @param article the web content article
+	* @param urlTitle the web content article's URL title
+	* @param serviceContext the service context to be applied. Can set the
+	modification date, status date, and portlet preferences. With
+	respect to social activities, by setting the service context's
+	command to {@link Constants#UPDATE}, the invocation is considered
+	a web content update activity; otherwise it is considered a web
+	content add activity.
+	* @return the updated web content article
+	*/
+	public static com.liferay.journal.model.JournalArticle updateUrlTitle(
+		com.liferay.journal.model.JournalArticle article, String urlTitle,
+		com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return getService().updateUrlTitle(article, urlTitle, serviceContext);
+	}
+
 	public static JournalArticleLocalService getService() {
 		return _serviceTracker.getService();
 	}

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalServiceWrapper.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalServiceWrapper.java
@@ -4255,6 +4255,28 @@ public class JournalArticleLocalServiceWrapper
 			oldDDMTemplateKey, newDDMTemplateKey);
 	}
 
+	/**
+	* Updates the URL title of the web content article.
+	*
+	* @param article the web content article
+	* @param urlTitle the web content article's URL title
+	* @param serviceContext the service context to be applied. Can set the
+	modification date, status date, and portlet preferences. With
+	respect to social activities, by setting the service context's
+	command to {@link Constants#UPDATE}, the invocation is considered
+	a web content update activity; otherwise it is considered a web
+	content add activity.
+	* @return the updated web content article
+	*/
+	@Override
+	public com.liferay.journal.model.JournalArticle updateUrlTitle(
+		com.liferay.journal.model.JournalArticle article, String urlTitle,
+		com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return _journalArticleLocalService.updateUrlTitle(article, urlTitle,
+			serviceContext);
+	}
+
 	@Override
 	public JournalArticleLocalService getWrappedService() {
 		return _journalArticleLocalService;

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
@@ -883,7 +883,7 @@ public class JournalArticleStagedModelDataHandler
 				article.getPrimaryKey(), importedArticle.getPrimaryKey());
 
 			_importFriendlyURLEntries(
-				portletDataContext, article, importedArticle);
+				portletDataContext, article, importedArticle, serviceContext);
 		}
 		finally {
 			if (smallFile != null) {
@@ -1139,7 +1139,7 @@ public class JournalArticleStagedModelDataHandler
 
 	private void _importFriendlyURLEntries(
 			PortletDataContext portletDataContext, JournalArticle article,
-			JournalArticle importedArticle)
+			JournalArticle importedArticle, ServiceContext serviceContext)
 		throws PortalException {
 
 		List<Element> friendlyURLEntryElements =
@@ -1164,9 +1164,9 @@ public class JournalArticleStagedModelDataHandler
 			_friendlyURLEntryLocalService.getMainFriendlyURLEntry(
 				JournalArticle.class, importedArticle.getResourcePrimKey());
 
-		importedArticle.setUrlTitle(mainFriendlyURLEntry.getUrlTitle());
-
-		_journalArticleLocalService.updateJournalArticle(importedArticle);
+		_journalArticleLocalService.updateUrlTitle(
+			importedArticle, mainFriendlyURLEntry.getUrlTitle(),
+			serviceContext);
 	}
 
 	/**

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -6622,6 +6622,39 @@ public class JournalArticleLocalServiceImpl
 			groupId, classNameId, oldDDMTemplateKey, newDDMTemplateKey);
 	}
 
+	/**
+	 * Updates the URL title of the web content article.
+	 *
+	 * @param  article the web content article
+	 * @param  urlTitle the web content article's URL title
+	 * @param  serviceContext the service context to be applied. Can set the
+	 *         modification date, status date, and portlet preferences. With
+	 *         respect to social activities, by setting the service context's
+	 *         command to {@link Constants#UPDATE}, the invocation is considered
+	 *         a web content update activity; otherwise it is considered a web
+	 *         content add activity.
+	 * @return the updated web content article
+	 */
+	@Indexable(type = IndexableType.REINDEX)
+	@Override
+	public JournalArticle updateUrlTitle(
+			JournalArticle article, String urlTitle,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		Date now = new Date();
+
+		Date modifiedDate = serviceContext.getModifiedDate(now);
+
+		article.setModifiedDate(modifiedDate);
+		
+		article.setUrlTitle(urlTitle);
+
+		journalArticlePersistence.update(article);
+
+		return article;
+	}
+
 	protected void addDocumentLibraryFileEntries(Element dynamicElementElement)
 		throws PortalException {
 


### PR DESCRIPTION
Hi @matethurzo ,

The root cause of the issue was that the modifiedDate of JournalArticle were updated when the import of friendly URLs finished. I added a new method in the `JournalArticleLocalService`, to update just the `urlTitle` separately.

Please review my changes.

Thanks,
Vendel