### PR TITLE
LPS-82569 Referenced content which is selected by default is not displayed on the modal at export and publish templates

### DIFF
--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/js/main.js
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/js/main.js
@@ -1043,22 +1043,11 @@ AUI.add(
 
 						var inputs = contentNode.all('.field');
 
-						var portletDataNode = instance.byId('PORTLET_DATA_' + portletId);
-
-						var portletChecked = portletDataNode.attr('checked');
-
 						var selectedContent = [];
 
 						inputs.each(
 							function(item, index, collection) {
-								var checked = false;
-
-								if (portletChecked) {
-									checked = item.attr(STR_CHECKED);
-								}
-								else {
-									item.attr(STR_CHECKED, false);
-								}
+								var checked = item.attr(STR_CHECKED);
 
 								if (checked) {
 									selectedContent.push(item.attr('data-name'));
@@ -1067,7 +1056,7 @@ AUI.add(
 						);
 
 						if (selectedContent.length === 0) {
-							portletDataNode.attr('checked', false);
+							instance.byId('PORTLET_DATA_' + portletId).attr('checked', false);
 
 							instance.byId('showChangeContent_' + portletId).hide();
 						}

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/js/main.js
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/js/main.js
@@ -1055,7 +1055,7 @@ AUI.add(
 							}
 						);
 
-						if (selectedContent.length === 0) {
+						if ((selectedContent.length === 0) || !instance.byId('PORTLET_DATA_' + portletId).attr('checked')) {
 							instance.byId('PORTLET_DATA_' + portletId).attr('checked', false);
 
 							instance.byId('showChangeContent_' + portletId).hide();

--- a/modules/apps/staging/staging-processes-web/src/main/resources/META-INF/resources/js/main.js
+++ b/modules/apps/staging/staging-processes-web/src/main/resources/META-INF/resources/js/main.js
@@ -902,7 +902,7 @@ AUI.add(
 							}
 						);
 
-						if (selectedContent.length === 0) {
+						if ((selectedContent.length === 0) || !instance.byId('PORTLET_DATA_' + portletId).attr('checked')) {
 							instance.byId('PORTLET_DATA_' + portletId).attr('checked', false);
 
 							instance.byId('showChangeContent_' + portletId).hide();

--- a/modules/apps/staging/staging-processes-web/src/main/resources/META-INF/resources/js/main.js
+++ b/modules/apps/staging/staging-processes-web/src/main/resources/META-INF/resources/js/main.js
@@ -890,22 +890,11 @@ AUI.add(
 
 						var inputs = contentNode.all('.field');
 
-						var portletDataNode = instance.byId('PORTLET_DATA_' + portletId);
-
-						var portletChecked = portletDataNode.attr('checked');
-
 						var selectedContent = [];
 
 						inputs.each(
 							function(item, index, collection) {
-								var checked = false;
-
-								if (portletChecked) {
-									checked = item.attr(STR_CHECKED);
-								}
-								else {
-									item.attr(STR_CHECKED, false);
-								}
+								var checked = item.attr(STR_CHECKED);
 
 								if (checked) {
 									selectedContent.push(item.attr('data-name'));
@@ -914,7 +903,7 @@ AUI.add(
 						);
 
 						if (selectedContent.length === 0) {
-							portletDataNode.attr('checked', false);
+							instance.byId('PORTLET_DATA_' + portletId).attr('checked', false);
 
 							instance.byId('showChangeContent_' + portletId).hide();
 						}


### PR DESCRIPTION
Hi Máté,

Tests ran: https://github.com/peterborkuti/liferay-portal/pull/68 failures are not related.

I made the regression bug with LPS-74465 and LPS-75511 (same code for staging and export-import).
I found a smaller fix which does not cause regression, so I reverted the old fixes first.

Thank you
Péter