### PR TITLE
[TECHNICAL-SUPPORT] LPS-82856

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/background/task/LayoutRemoteStagingBackgroundTaskExecutor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/background/task/LayoutRemoteStagingBackgroundTaskExecutor.java
@@ -25,6 +25,7 @@ import com.liferay.exportimport.kernel.staging.StagingUtil;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTask;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskExecutor;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskResult;
+import com.liferay.portal.kernel.exception.NoSuchLayoutException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.log.Log;
@@ -45,6 +46,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * @author Mate Thurzo
@@ -200,13 +202,24 @@ public class LayoutRemoteStagingBackgroundTaskExecutor
 		List<Layout> layouts = new ArrayList<>();
 
 		if (layoutIdMap != null) {
-			for (Map.Entry<Long, Boolean> entry : layoutIdMap.entrySet()) {
+			Set<Map.Entry<Long, Boolean>> entrySet = layoutIdMap.entrySet();
+
+			for (Map.Entry<Long, Boolean> entry : entrySet) {
 				long plid = GetterUtil.getLong(String.valueOf(entry.getKey()));
 				boolean includeChildren = entry.getValue();
 
-				Layout layout =
-					ExportImportHelperUtil.getLayoutOrCreateDummyRootLayout(
-						plid);
+				Layout layout = null;
+
+				try {
+					layout =
+						ExportImportHelperUtil.getLayoutOrCreateDummyRootLayout(
+							plid);
+				}
+				catch (NoSuchLayoutException nsle) {
+					entrySet.remove(plid);
+
+					continue;
+				}
 
 				if (!layouts.contains(layout)) {
 					layouts.add(layout);

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/ExportImportHelperImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/ExportImportHelperImpl.java
@@ -102,6 +102,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 
 import javax.portlet.PortletPreferences;
@@ -452,10 +453,27 @@ public class ExportImportHelperImpl implements ExportImportHelper {
 
 		List<Layout> layouts = new ArrayList<>();
 
-		for (Map.Entry<Long, Boolean> entry : layoutIdMap.entrySet()) {
+		Set<Map.Entry<Long, Boolean>> entrySet = layoutIdMap.entrySet();
+
+		for (Map.Entry<Long, Boolean> entry : entrySet) {
 			long plid = GetterUtil.getLong(String.valueOf(entry.getKey()));
 
-			Layout layout = getLayoutOrCreateDummyRootLayout(plid);
+			Layout layout = null;
+
+			try {
+				layout = getLayoutOrCreateDummyRootLayout(plid);
+			}
+			catch (NoSuchLayoutException nsle) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(
+						"Deleted layout could not be published (plid " + plid +
+							")");
+				}
+
+				entrySet.remove(plid);
+
+				continue;
+			}
 
 			if (!layouts.contains(layout)) {
 				layouts.add(layout);


### PR DESCRIPTION
/cc @SamZiemer

Relevant tickets:

https://issues.liferay.com/browse/LPP-30605
https://issues.liferay.com/browse/LPS-82856

> Scheduled publications when using remote live staging will fail if a page that is scheduled to be published is deleted prior to the publication.
> 
> This is because the settings map that indicates which layouts to publish (configured at the time of scheduling the publication) is reused when the publication is executed to determine which layouts to publish. Any number of these layouts could have been deleted since that time, but it does not handle this case gracefully.
> 
> I think the correct way to handle this is to simply add a little more error checking/handling. Let me know if there are any other problems with this I did not foresee, though. Thanks!

Sending to you as per request: https://github.com/SamZiemer/liferay-portal/pull/462#issuecomment-401849666

Thank you!