### PR TITLE
[TECHNICAL-SUPPORT] LPS-82856

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/background/task/LayoutRemoteStagingBackgroundTaskExecutor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/background/task/LayoutRemoteStagingBackgroundTaskExecutor.java
@@ -216,6 +216,13 @@ public class LayoutRemoteStagingBackgroundTaskExecutor
 							plid);
 				}
 				catch (NoSuchLayoutException nsle) {
+
+					// see LPS-36174
+
+					if (_log.isDebugEnabled()) {
+						_log.debug(nsle, nsle);
+					}
+
 					entrySet.remove(plid);
 
 					continue;

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/ExportImportHelperImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/ExportImportHelperImpl.java
@@ -470,6 +470,12 @@ public class ExportImportHelperImpl implements ExportImportHelper {
 							")");
 				}
 
+				// see LPS-36174
+
+				if (_log.isDebugEnabled()) {
+					_log.debug(nsle, nsle);
+				}
+
 				entrySet.remove(plid);
 
 				continue;


### PR DESCRIPTION
/cc @SamZiemer

Relevant tickets:

https://issues.liferay.com/browse/LPP-30605
https://issues.liferay.com/browse/LPS-82856

Re-sending to fix source formatting errors. Notes copied from https://github.com/matethurzo/liferay-portal/pull/2162:

> Scheduled publications when using remote live staging will fail if a page that is scheduled to be published is deleted prior to the publication.
> 
> This is because the settings map that indicates which layouts to publish (configured at the time of scheduling the publication) is reused when the publication is executed to determine which layouts to publish. Any number of these layouts could have been deleted since that time, but it does not handle this case gracefully.
> 
> I think the correct way to handle this is to simply add a little more error checking/handling. Let me know if there are any other problems with this I did not foresee, though. Thanks!

> Sending to you as per request: https://github.com/SamZiemer/liferay-portal/pull/462#issuecomment-401849666

Due to LPS-36174, I had to at least add debug logging to process the exception, or the source formatter won't let it pass. I figured it would have to be debug logging, because it would be confusing to print the stack trace to the logs if it doesn't actually represent an error.

Thank you!