### PR TITLE
[TECHNICAL-SUPPORT] LPS-83795

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/exportimport/portlet/preferences/processor/AssetPublisherExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/exportimport/portlet/preferences/processor/AssetPublisherExportImportPortletPreferencesProcessor.java
@@ -18,6 +18,7 @@ import com.liferay.asset.kernel.AssetRendererFactoryRegistryUtil;
 import com.liferay.asset.kernel.model.AssetCategory;
 import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.model.AssetRenderer;
+import com.liferay.asset.kernel.model.AssetRendererFactory;
 import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.service.AssetCategoryLocalService;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
@@ -33,6 +34,7 @@ import com.liferay.dynamic.data.mapping.kernel.DDMStructureManager;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
 import com.liferay.dynamic.data.mapping.util.DDMIndexer;
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.kernel.lar.PortletDataException;
 import com.liferay.exportimport.kernel.lar.PortletDataHandlerKeys;
@@ -258,6 +260,18 @@ public class AssetPublisherExportImportPortletPreferencesProcessor
 
 			if ((assetRenderer == null) ||
 				!(assetRenderer.getAssetObject() instanceof StagedModel)) {
+
+				continue;
+			}
+
+			AssetRendererFactory assetRendererFactory =
+				assetRenderer.getAssetRendererFactory();
+
+			Group group = _groupLocalService.getGroup(assetEntry.getGroupId());
+
+			if ((assetRendererFactory != null) &&
+				ExportImportThreadLocal.isStagingInProcess() &&
+				!group.isStagedPortlet(assetRendererFactory.getPortletId())) {
 
 				continue;
 			}


### PR DESCRIPTION
/cc @moltam89

> Relevant tickets:
> 
> https://issues.liferay.com/browse/LPP-30959
> https://issues.liferay.com/browse/LPS-83795
> 
> If Staging is configured for a site but it is disabled for a specific portlet in the configuration (like Web Content or Calendar), having an Asset Publisher can still cause the portlet data to be staged as if it were enabled. This is because the Asset Publisher itself is exporting all references without checking for whether Staging is enabled for each specific type of asset entry.
> 
> I think the expected behavior is, for any type of content, whenever Staging for it is disabled in the configuration, that means it should not be published over, and the staging and live sites treated separately (in the case of local Staging, it can do the fancy direct live modification from the Staging site for that type of content, and otherwise the two treated totally independently). It's my understanding the presence of an Asset Publisher should not be a factor in this behavior.
> 
> With this change, if a portlet (like Calendar) can be staged but has Staging disabled, and an Asset Publisher references that portlet's content, then:
> 
> - With local Staging, the Staging site does not have the content, so the Asset Publisher does not display it. Instead the relevant portlet directly modifies the live site (which matches the expected pattern for non-staged content; it should be modified directly on the live site instead), and only the live site has the originally present content.
> - With remote Staging, the remote (live) site does not get the portlet data either (after a publish), though more can be added to either independently.
> - In both cases, the portlet's content is never published because it was not configured.