### PR TITLE
[TECHNICAL SUPPORT] LPS-83849 Avoid warnings during export/import

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/content/processor/LayoutReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/content/processor/LayoutReferencesExportImportContentProcessor.java
@@ -252,6 +252,12 @@ public class LayoutReferencesExportImportContentProcessor
 
 			String url = content.substring(beginPos + offset, endPos);
 
+			endPos = url.indexOf(Portal.FRIENDLY_URL_SEPARATOR);
+
+			if (endPos != -1) {
+				url = url.substring(0, endPos);
+			}
+
 			if (url.endsWith(StringPool.SLASH)) {
 				url = url.substring(0, url.length() - 1);
 			}

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/content/processor/LayoutReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/content/processor/LayoutReferencesExportImportContentProcessor.java
@@ -252,10 +252,11 @@ public class LayoutReferencesExportImportContentProcessor
 
 			String url = content.substring(beginPos + offset, endPos);
 
-			endPos = url.indexOf(Portal.FRIENDLY_URL_SEPARATOR);
+			int pos = url.indexOf(Portal.FRIENDLY_URL_SEPARATOR);
 
-			if (endPos != -1) {
-				url = url.substring(0, endPos);
+			if (pos != -1) {
+				url = url.substring(0, pos);
+				endPos = beginPos + offset + pos;
 			}
 
 			if (url.endsWith(StringPool.SLASH)) {
@@ -287,7 +288,7 @@ public class LayoutReferencesExportImportContentProcessor
 					continue;
 				}
 
-				int pos = url.indexOf(StringPool.SLASH, 1);
+				pos = url.indexOf(StringPool.SLASH, 1);
 
 				String localePath = StringPool.BLANK;
 

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/content/processor/JournalFeedReferencesExportImportContentProcessor.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/content/processor/JournalFeedReferencesExportImportContentProcessor.java
@@ -222,6 +222,7 @@ public class JournalFeedReferencesExportImportContentProcessor
 
 				StringBundler exportedReferenceSB = new StringBundler(3);
 
+				exportedReferenceSB.append(Portal.FRIENDLY_URL_SEPARATOR);
 				exportedReferenceSB.append("[$journalfeed-reference=");
 				exportedReferenceSB.append(path);
 				exportedReferenceSB.append("$]");
@@ -290,7 +291,9 @@ public class JournalFeedReferencesExportImportContentProcessor
 					groupId, className, classPK);
 			}
 
-			String exportedReference = "[$journalfeed-reference=" + path + "$]";
+			String exportedReference =
+				Portal.FRIENDLY_URL_SEPARATOR + "[$journalfeed-reference=" +
+					path + "$]";
 
 			if (!content.contains(exportedReference)) {
 				continue;

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/content/processor/JournalFeedReferencesExportImportContentProcessor.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/content/processor/JournalFeedReferencesExportImportContentProcessor.java
@@ -220,7 +220,7 @@ public class JournalFeedReferencesExportImportContentProcessor
 
 				String path = ExportImportPathUtil.getModelPath(journalFeed);
 
-				StringBundler exportedReferenceSB = new StringBundler(3);
+				StringBundler exportedReferenceSB = new StringBundler(4);
 
 				exportedReferenceSB.append(Portal.FRIENDLY_URL_SEPARATOR);
 				exportedReferenceSB.append("[$journalfeed-reference=");

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/content/processor/JournalFeedReferencesExportImportContentProcessor.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/content/processor/JournalFeedReferencesExportImportContentProcessor.java
@@ -290,7 +290,9 @@ public class JournalFeedReferencesExportImportContentProcessor
 					groupId, className, classPK);
 			}
 
-			if (!content.contains("[$journalfeed-reference=" + path + "$]")) {
+			String exportedReference = "[$journalfeed-reference=" + path + "$]";
+
+			if (!content.contains(exportedReference)) {
 				continue;
 			}
 
@@ -328,10 +330,6 @@ public class JournalFeedReferencesExportImportContentProcessor
 			long journalFeedId = MapUtil.getLong(
 				journalFeedIds, classPK, classPK);
 
-			int beginPos = content.indexOf("[$journalfeed-reference=" + path);
-
-			int endPos = content.indexOf("$]", beginPos) + 2;
-
 			JournalFeed importedJournalFeed = null;
 
 			try {
@@ -346,22 +344,6 @@ public class JournalFeedReferencesExportImportContentProcessor
 					_log.warn(pe.getMessage());
 				}
 
-				if (content.startsWith("[#journalfeed-reference=", endPos)) {
-					int prefixPos =
-						endPos + "[#journalfeed-reference=".length();
-
-					int postfixPos = content.indexOf("#]", prefixPos);
-
-					String originalReference = content.substring(
-						prefixPos, postfixPos);
-
-					String exportedReference = content.substring(
-						beginPos, postfixPos + 2);
-
-					content = StringUtil.replace(
-						content, exportedReference, originalReference);
-				}
-
 				continue;
 			}
 
@@ -369,14 +351,6 @@ public class JournalFeedReferencesExportImportContentProcessor
 				_JOURNAL_FEED_FRIENDLY_URL,
 				String.valueOf(importedJournalFeed.getGroupId()), "/",
 				importedJournalFeed.getFeedId());
-
-			String exportedReference = "[$journalfeed-reference=" + path + "$]";
-
-			if (content.startsWith("[#journalfeed-reference=", endPos)) {
-				endPos = content.indexOf("#]", beginPos) + 2;
-
-				exportedReference = content.substring(beginPos, endPos);
-			}
 
 			content = StringUtil.replace(content, exportedReference, url);
 		}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-83849

**This LPS was detected during [LPS-82757](https://issues.liferay.com/browse/LPS-82757) resolution.**

In case of having a link with friendly url:
  - http://localhost:8080/web/mysite/mypage/-/portlet/friendly/226268/226312
a warning is produced.

To avoid that warning, I am using "/-/" as separator, so we only process the page link until "/-/" characters.

**Other changes:**
 - About https://github.com/matethurzo/liferay-portal/pull/2211/commits/dd3e5a8ab2c27bd9bb2c01abdeb81535daa0a6bb it was added in [LPS-82757](https://issues.liferay.com/browse/LPS-82757), but I have realized that is not used (I created the JournalFeedReferences content processor from a copy of document library, and there this code was related to recycle bin)
 - About https://github.com/matethurzo/liferay-portal/pull/2211/commits/3b37083faea765f3bf5a7ad36e2f92c3f6542807 in [LPS-82757](https://issues.liferay.com/browse/LPS-82757)  we are replacing **/-/journal/rss/...** url fragment with **[$journalfeed-reference=...]** that causes problems with new LPS-83849 code, that search the "/-/" string.
To avoid that, I am changing JournalFeed replacement: **/-/journal/rss/...** is now rewritten to **/-/[$journalfeed-reference=...]** 

/cc: @moltam89