### PR TITLE
[TECHNICAL SUPPORT] LPS-84201

### DIFF
--- a/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/lar/test/AssetPublisherExportImportTest.java
+++ b/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/lar/test/AssetPublisherExportImportTest.java
@@ -248,10 +248,10 @@ public class AssetPublisherExportImportTest
 
 			Assert.assertEquals(
 				null, portletPreferences.getValue("scopeId", null));
-			Assert.assertTrue(
-				"The child group ID should have been filtered out on import",
-				ArrayUtil.isEmpty(
-					portletPreferences.getValues("scopeIds", null)));
+			Assert.assertEquals(
+				AssetPublisherHelper.SCOPE_ID_GROUP_PREFIX +
+					childGroup.getGroupId(),
+				portletPreferences.getValue("scopeIds", null));
 		}
 		finally {
 			GroupLocalServiceUtil.deleteGroup(childGroup);

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/exportimport/portlet/preferences/processor/AssetPublisherExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/exportimport/portlet/preferences/processor/AssetPublisherExportImportPortletPreferencesProcessor.java
@@ -1007,6 +1007,8 @@ public class AssetPublisherExportImportPortletPreferencesProcessor
 				newValues[i] =
 					AssetPublisherUtil.SCOPE_ID_LAYOUT_UUID_PREFIX +
 						scopeIdLayout.getUuid();
+
+				continue;
 			}
 			else if (oldValue.startsWith(
 						 AssetPublisherUtil.SCOPE_ID_LAYOUT_UUID_PREFIX)) {
@@ -1026,6 +1028,8 @@ public class AssetPublisherExportImportPortletPreferencesProcessor
 				}
 
 				newValues[i] = oldValue;
+
+				continue;
 			}
 			else {
 				newValues[i] = oldValue;

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/exportimport/portlet/preferences/processor/AssetPublisherExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/exportimport/portlet/preferences/processor/AssetPublisherExportImportPortletPreferencesProcessor.java
@@ -53,6 +53,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.Organization;
 import com.liferay.portal.kernel.model.Portlet;
@@ -1036,18 +1037,18 @@ public class AssetPublisherExportImportPortletPreferencesProcessor
 
 			Group group = _groupLocalService.fetchGroup(groupId);
 
-			long liveGroupId = 0;
-
-			if (group != null) {
-				liveGroupId = group.getLiveGroupId();
-
-				if (group.isStagedRemotely()) {
-					liveGroupId = group.getRemoteLiveGroupId();
-				}
+			if (group == null) {
+				continue;
 			}
 
-			if ((groupId == 0) || (liveGroupId == 0)) {
-				continue;
+			long liveGroupId = group.getLiveGroupId();
+
+			if (group.isStagedRemotely()) {
+				liveGroupId = group.getRemoteLiveGroupId();
+			}
+
+			if (liveGroupId == GroupConstants.DEFAULT_LIVE_GROUP_ID) {
+				liveGroupId = group.getGroupId();
 			}
 
 			newValues[i] = String.valueOf(groupId);
@@ -1059,6 +1060,8 @@ public class AssetPublisherExportImportPortletPreferencesProcessor
 				"group-id", String.valueOf(groupId));
 			groupIdMappingElement.addAttribute(
 				"live-group-id", String.valueOf(liveGroupId));
+			groupIdMappingElement.addAttribute(
+				"group-key", group.getGroupKey());
 		}
 
 		portletPreferences.setValues(key, newValues);

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/exportimport/portlet/preferences/processor/AssetPublisherExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/exportimport/portlet/preferences/processor/AssetPublisherExportImportPortletPreferencesProcessor.java
@@ -23,9 +23,9 @@ import com.liferay.asset.kernel.service.AssetCategoryLocalService;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
 import com.liferay.asset.kernel.service.persistence.AssetEntryQuery;
 import com.liferay.asset.publisher.constants.AssetPublisherPortletKeys;
+import com.liferay.asset.publisher.util.AssetPublisherHelper;
 import com.liferay.asset.publisher.web.configuration.AssetPublisherWebConfiguration;
 import com.liferay.asset.publisher.web.internal.util.AssetPublisherWebUtil;
-import com.liferay.asset.publisher.web.util.AssetPublisherUtil;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFileEntryType;
 import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
@@ -227,7 +227,7 @@ public class AssetPublisherExportImportPortletPreferencesProcessor
 			}
 
 			BaseModelSearchResult<AssetEntry> baseModelSearchResult =
-				AssetPublisherUtil.getAssetEntries(
+				assetPublisherHelper.getAssetEntries(
 					assetEntryQuery, layout, portletPreferences,
 					AssetPublisherPortletKeys.ASSET_PUBLISHER,
 					LocaleUtil.getDefault(), TimeZoneUtil.getDefault(),
@@ -244,11 +244,11 @@ public class AssetPublisherExportImportPortletPreferencesProcessor
 				return;
 			}
 
-			long[] groupIds = AssetPublisherUtil.getGroupIds(
+			long[] groupIds = assetPublisherHelper.getGroupIds(
 				portletPreferences, portletDataContext.getScopeGroupId(),
 				layout);
 
-			assetEntries = AssetPublisherUtil.getAssetEntries(
+			assetEntries = assetPublisherHelper.getAssetEntries(
 				null, portletPreferences,
 				PermissionThreadLocal.getPermissionChecker(), groupIds, false,
 				false);
@@ -274,10 +274,11 @@ public class AssetPublisherExportImportPortletPreferencesProcessor
 			PortletPreferences portletPreferences)
 		throws Exception {
 
-		AssetEntryQuery assetEntryQuery = AssetPublisherUtil.getAssetEntryQuery(
-			portletPreferences, groupId, layout, null, null);
+		AssetEntryQuery assetEntryQuery =
+			assetPublisherHelper.getAssetEntryQuery(
+				portletPreferences, groupId, layout, null, null);
 
-		long[] classNameIds = AssetPublisherUtil.getClassNameIds(
+		long[] classNameIds = assetPublisherHelper.getClassNameIds(
 			portletPreferences,
 			AssetRendererFactoryRegistryUtil.getClassNameIds(companyId, true));
 
@@ -962,7 +963,7 @@ public class AssetPublisherExportImportPortletPreferencesProcessor
 		Layout layout = _layoutLocalService.getLayout(plid);
 
 		String companyGroupScopeId =
-			AssetPublisherUtil.SCOPE_ID_GROUP_PREFIX +
+			AssetPublisherHelper.SCOPE_ID_GROUP_PREFIX +
 				portletDataContext.getCompanyGroupId();
 
 		String[] newValues = new String[oldValues.length];
@@ -975,7 +976,9 @@ public class AssetPublisherExportImportPortletPreferencesProcessor
 		for (int i = 0; i < oldValues.length; i++) {
 			String oldValue = oldValues[i];
 
-			if (oldValue.startsWith(AssetPublisherUtil.SCOPE_ID_GROUP_PREFIX)) {
+			if (oldValue.startsWith(
+					AssetPublisherHelper.SCOPE_ID_GROUP_PREFIX)) {
+
 				newValues[i] = StringUtil.replace(
 					oldValue, companyGroupScopeId,
 					"[$COMPANY_GROUP_SCOPE_ID$]");
@@ -985,12 +988,12 @@ public class AssetPublisherExportImportPortletPreferencesProcessor
 				}
 			}
 			else if (oldValue.startsWith(
-						 AssetPublisherUtil.SCOPE_ID_LAYOUT_PREFIX)) {
+						 AssetPublisherHelper.SCOPE_ID_LAYOUT_PREFIX)) {
 
 				// Legacy preferences
 
 				String scopeIdSuffix = oldValue.substring(
-					AssetPublisherUtil.SCOPE_ID_LAYOUT_PREFIX.length());
+					AssetPublisherHelper.SCOPE_ID_LAYOUT_PREFIX.length());
 
 				long scopeIdLayoutId = GetterUtil.getLong(scopeIdSuffix);
 
@@ -1005,16 +1008,16 @@ public class AssetPublisherExportImportPortletPreferencesProcessor
 				}
 
 				newValues[i] =
-					AssetPublisherUtil.SCOPE_ID_LAYOUT_UUID_PREFIX +
+					AssetPublisherHelper.SCOPE_ID_LAYOUT_UUID_PREFIX +
 						scopeIdLayout.getUuid();
 
 				continue;
 			}
 			else if (oldValue.startsWith(
-						 AssetPublisherUtil.SCOPE_ID_LAYOUT_UUID_PREFIX)) {
+						 AssetPublisherHelper.SCOPE_ID_LAYOUT_UUID_PREFIX)) {
 
 				String scopeLayoutUuid = oldValue.substring(
-					AssetPublisherUtil.SCOPE_ID_LAYOUT_UUID_PREFIX.length());
+					AssetPublisherHelper.SCOPE_ID_LAYOUT_UUID_PREFIX.length());
 
 				Layout scopeUuidLayout =
 					_layoutLocalService.getLayoutByUuidAndGroupId(
@@ -1035,7 +1038,7 @@ public class AssetPublisherExportImportPortletPreferencesProcessor
 				newValues[i] = oldValue;
 			}
 
-			long groupId = AssetPublisherUtil.getGroupIdFromScopeId(
+			long groupId = assetPublisherHelper.getGroupIdFromScopeId(
 				newValues[i], portletDataContext.getGroupId(),
 				portletDataContext.isPrivateLayout());
 
@@ -1269,7 +1272,7 @@ public class AssetPublisherExportImportPortletPreferencesProcessor
 		Layout layout = _layoutLocalService.getLayout(plid);
 
 		String companyGroupScopeId =
-			AssetPublisherUtil.SCOPE_ID_GROUP_PREFIX + companyGroupId;
+			AssetPublisherHelper.SCOPE_ID_GROUP_PREFIX + companyGroupId;
 
 		List<String> newValues = new ArrayList<>(oldValues.length);
 
@@ -1284,7 +1287,7 @@ public class AssetPublisherExportImportPortletPreferencesProcessor
 					groupIds.get(Long.valueOf(oldValue)));
 
 				if (group != null) {
-					newValue = AssetPublisherUtil.getScopeId(
+					newValue = assetPublisherHelper.getScopeId(
 						group, portletDataContext.getScopeGroupId());
 				}
 			}
@@ -1349,6 +1352,9 @@ public class AssetPublisherExportImportPortletPreferencesProcessor
 
 	@Reference(target = "(name=AssetPublisherImportCapability)")
 	protected Capability assetImportCapability;
+
+	@Reference
+	protected AssetPublisherHelper assetPublisherHelper;
 
 	@Reference
 	protected AssetPublisherWebUtil assetPublisherWebUtil;

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/exportimport/portlet/preferences/processor/AssetPublisherExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/exportimport/portlet/preferences/processor/AssetPublisherExportImportPortletPreferencesProcessor.java
@@ -1259,6 +1259,10 @@ public class AssetPublisherExportImportPortletPreferencesProcessor
 		for (String oldValue : oldValues) {
 			String newValue = oldValue;
 
+			if ("[$COMPANY_GROUP_SCOPE_ID$]".equals(oldValue)) {
+				oldValue = String.valueOf(companyGroupId);
+			}
+
 			if (Validator.isNumber(oldValue) &&
 				groupIds.containsKey(Long.valueOf(oldValue))) {
 

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/exportimport/portlet/preferences/processor/AssetPublisherExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/exportimport/portlet/preferences/processor/AssetPublisherExportImportPortletPreferencesProcessor.java
@@ -395,19 +395,6 @@ public class AssetPublisherExportImportPortletPreferencesProcessor
 			Element groupIdMappingsElement, Layout layout, String value)
 		throws PortalException, PortletDataException {
 
-		if (value.startsWith(AssetPublisherHelper.SCOPE_ID_GROUP_PREFIX)) {
-			String companyGroupScopeId =
-				AssetPublisherHelper.SCOPE_ID_GROUP_PREFIX +
-					portletDataContext.getCompanyGroupId();
-
-			value = StringUtil.replace(
-				value, companyGroupScopeId, "[$COMPANY_GROUP_SCOPE_ID$]");
-
-			if (value.contains("[$COMPANY_GROUP_SCOPE_ID$]")) {
-				return value;
-			}
-		}
-
 		if (value.startsWith(AssetPublisherHelper.SCOPE_ID_LAYOUT_PREFIX)) {
 
 			// Legacy preferences
@@ -1267,14 +1254,10 @@ public class AssetPublisherExportImportPortletPreferencesProcessor
 
 		Layout layout = _layoutLocalService.getLayout(plid);
 
-		String companyGroupScopeId =
-			AssetPublisherHelper.SCOPE_ID_GROUP_PREFIX + companyGroupId;
-
 		List<String> newValues = new ArrayList<>(oldValues.length);
 
 		for (String oldValue : oldValues) {
-			String newValue = StringUtil.replace(
-				oldValue, "[$COMPANY_GROUP_SCOPE_ID$]", companyGroupScopeId);
+			String newValue = oldValue;
 
 			if (Validator.isNumber(oldValue) &&
 				groupIds.containsKey(Long.valueOf(oldValue))) {

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/exportimport/portlet/preferences/processor/AssetPublisherExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/exportimport/portlet/preferences/processor/AssetPublisherExportImportPortletPreferencesProcessor.java
@@ -49,6 +49,7 @@ import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.NoSuchGroupException;
 import com.liferay.portal.kernel.exception.NoSuchLayoutException;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
@@ -387,6 +388,97 @@ public class AssetPublisherExportImportPortletPreferencesProcessor
 		}
 
 		return StringUtil.merge(new Object[] {uuid, groupId}, StringPool.POUND);
+	}
+
+	protected String getExportScopeId(
+			PortletDataContext portletDataContext,
+			Element groupIdMappingsElement, Layout layout, String value)
+		throws PortalException, PortletDataException {
+
+		if (value.startsWith(AssetPublisherHelper.SCOPE_ID_GROUP_PREFIX)) {
+			String companyGroupScopeId =
+				AssetPublisherHelper.SCOPE_ID_GROUP_PREFIX +
+					portletDataContext.getCompanyGroupId();
+
+			value = StringUtil.replace(
+				value, companyGroupScopeId, "[$COMPANY_GROUP_SCOPE_ID$]");
+
+			if (value.contains("[$COMPANY_GROUP_SCOPE_ID$]")) {
+				return value;
+			}
+		}
+
+		if (value.startsWith(AssetPublisherHelper.SCOPE_ID_LAYOUT_PREFIX)) {
+
+			// Legacy preferences
+
+			String scopeIdSuffix = value.substring(
+				AssetPublisherHelper.SCOPE_ID_LAYOUT_PREFIX.length());
+
+			long scopeIdLayoutId = GetterUtil.getLong(scopeIdSuffix);
+
+			Layout scopeIdLayout = _layoutLocalService.getLayout(
+				layout.getGroupId(), layout.isPrivateLayout(), scopeIdLayoutId);
+
+			if (layout.getPlid() != scopeIdLayout.getPlid()) {
+				StagedModelDataHandlerUtil.exportReferenceStagedModel(
+					portletDataContext, portletDataContext.getPortletId(),
+					scopeIdLayout);
+			}
+
+			return AssetPublisherHelper.SCOPE_ID_LAYOUT_UUID_PREFIX +
+				scopeIdLayout.getUuid();
+		}
+
+		if (value.startsWith(
+				AssetPublisherHelper.SCOPE_ID_LAYOUT_UUID_PREFIX)) {
+
+			String scopeLayoutUuid = value.substring(
+				AssetPublisherHelper.SCOPE_ID_LAYOUT_UUID_PREFIX.length());
+
+			Layout scopeUuidLayout =
+				_layoutLocalService.getLayoutByUuidAndGroupId(
+					scopeLayoutUuid, portletDataContext.getGroupId(),
+					portletDataContext.isPrivateLayout());
+
+			if (layout.getPlid() != scopeUuidLayout.getPlid()) {
+				StagedModelDataHandlerUtil.exportReferenceStagedModel(
+					portletDataContext, portletDataContext.getPortletId(),
+					scopeUuidLayout);
+			}
+
+			return value;
+		}
+
+		long groupId = assetPublisherHelper.getGroupIdFromScopeId(
+			value, portletDataContext.getGroupId(),
+			portletDataContext.isPrivateLayout());
+
+		Group group = _groupLocalService.fetchGroup(groupId);
+
+		if (group == null) {
+			return value;
+		}
+
+		long liveGroupId = group.getLiveGroupId();
+
+		if (group.isStagedRemotely()) {
+			liveGroupId = group.getRemoteLiveGroupId();
+		}
+
+		if (liveGroupId == GroupConstants.DEFAULT_LIVE_GROUP_ID) {
+			liveGroupId = group.getGroupId();
+		}
+
+		Element groupIdMappingElement = groupIdMappingsElement.addElement(
+			"group-id-mapping");
+
+		groupIdMappingElement.addAttribute("group-id", String.valueOf(groupId));
+		groupIdMappingElement.addAttribute(
+			"live-group-id", String.valueOf(liveGroupId));
+		groupIdMappingElement.addAttribute("group-key", group.getGroupKey());
+
+		return String.valueOf(groupId);
 	}
 
 	@Override
@@ -962,10 +1054,6 @@ public class AssetPublisherExportImportPortletPreferencesProcessor
 
 		Layout layout = _layoutLocalService.getLayout(plid);
 
-		String companyGroupScopeId =
-			AssetPublisherHelper.SCOPE_ID_GROUP_PREFIX +
-				portletDataContext.getCompanyGroupId();
-
 		String[] newValues = new String[oldValues.length];
 
 		Element rootElement = portletDataContext.getExportDataRootElement();
@@ -974,101 +1062,9 @@ public class AssetPublisherExportImportPortletPreferencesProcessor
 			"group-id-mappings");
 
 		for (int i = 0; i < oldValues.length; i++) {
-			String oldValue = oldValues[i];
-
-			if (oldValue.startsWith(
-					AssetPublisherHelper.SCOPE_ID_GROUP_PREFIX)) {
-
-				newValues[i] = StringUtil.replace(
-					oldValue, companyGroupScopeId,
-					"[$COMPANY_GROUP_SCOPE_ID$]");
-
-				if (newValues[i].contains("[$COMPANY_GROUP_SCOPE_ID$]")) {
-					continue;
-				}
-			}
-			else if (oldValue.startsWith(
-						 AssetPublisherHelper.SCOPE_ID_LAYOUT_PREFIX)) {
-
-				// Legacy preferences
-
-				String scopeIdSuffix = oldValue.substring(
-					AssetPublisherHelper.SCOPE_ID_LAYOUT_PREFIX.length());
-
-				long scopeIdLayoutId = GetterUtil.getLong(scopeIdSuffix);
-
-				Layout scopeIdLayout = _layoutLocalService.getLayout(
-					layout.getGroupId(), layout.isPrivateLayout(),
-					scopeIdLayoutId);
-
-				if (plid != scopeIdLayout.getPlid()) {
-					StagedModelDataHandlerUtil.exportReferenceStagedModel(
-						portletDataContext, portletDataContext.getPortletId(),
-						scopeIdLayout);
-				}
-
-				newValues[i] =
-					AssetPublisherHelper.SCOPE_ID_LAYOUT_UUID_PREFIX +
-						scopeIdLayout.getUuid();
-
-				continue;
-			}
-			else if (oldValue.startsWith(
-						 AssetPublisherHelper.SCOPE_ID_LAYOUT_UUID_PREFIX)) {
-
-				String scopeLayoutUuid = oldValue.substring(
-					AssetPublisherHelper.SCOPE_ID_LAYOUT_UUID_PREFIX.length());
-
-				Layout scopeUuidLayout =
-					_layoutLocalService.getLayoutByUuidAndGroupId(
-						scopeLayoutUuid, portletDataContext.getGroupId(),
-						portletDataContext.isPrivateLayout());
-
-				if (plid != scopeUuidLayout.getPlid()) {
-					StagedModelDataHandlerUtil.exportReferenceStagedModel(
-						portletDataContext, portletDataContext.getPortletId(),
-						scopeUuidLayout);
-				}
-
-				newValues[i] = oldValue;
-
-				continue;
-			}
-			else {
-				newValues[i] = oldValue;
-			}
-
-			long groupId = assetPublisherHelper.getGroupIdFromScopeId(
-				newValues[i], portletDataContext.getGroupId(),
-				portletDataContext.isPrivateLayout());
-
-			Group group = _groupLocalService.fetchGroup(groupId);
-
-			if (group == null) {
-				continue;
-			}
-
-			long liveGroupId = group.getLiveGroupId();
-
-			if (group.isStagedRemotely()) {
-				liveGroupId = group.getRemoteLiveGroupId();
-			}
-
-			if (liveGroupId == GroupConstants.DEFAULT_LIVE_GROUP_ID) {
-				liveGroupId = group.getGroupId();
-			}
-
-			newValues[i] = String.valueOf(groupId);
-
-			Element groupIdMappingElement = groupIdMappingsElement.addElement(
-				"group-id-mapping");
-
-			groupIdMappingElement.addAttribute(
-				"group-id", String.valueOf(groupId));
-			groupIdMappingElement.addAttribute(
-				"live-group-id", String.valueOf(liveGroupId));
-			groupIdMappingElement.addAttribute(
-				"group-key", group.getGroupKey());
+			newValues[i] = getExportScopeId(
+				portletDataContext, groupIdMappingsElement, layout, 
+				oldValues[i]);
 		}
 
 		portletPreferences.setValues(key, newValues);

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/exportimport/portlet/preferences/processor/AssetPublisherExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/exportimport/portlet/preferences/processor/AssetPublisherExportImportPortletPreferencesProcessor.java
@@ -1050,7 +1050,7 @@ public class AssetPublisherExportImportPortletPreferencesProcessor
 
 		for (int i = 0; i < oldValues.length; i++) {
 			newValues[i] = getExportScopeId(
-				portletDataContext, groupIdMappingsElement, layout, 
+				portletDataContext, groupIdMappingsElement, layout,
 				oldValues[i]);
 		}
 
@@ -1263,27 +1263,28 @@ public class AssetPublisherExportImportPortletPreferencesProcessor
 				oldValue = String.valueOf(companyGroupId);
 			}
 
-			if (Validator.isNumber(oldValue) &&
-				groupIds.containsKey(Long.valueOf(oldValue))) {
+			if (Validator.isNumber(oldValue)) {
+				long groupId = Long.valueOf(oldValue);
 
-				Group group = _groupLocalService.fetchGroup(
-					groupIds.get(Long.valueOf(oldValue)));
-
-				if (group != null) {
-					newValue = assetPublisherHelper.getScopeId(
-						group, portletDataContext.getScopeGroupId());
-				}
-			}
-
-			if (Validator.isNumber(newValue)) {
-				if (_log.isInfoEnabled()) {
-					_log.info(
-						StringBundler.concat(
-							"Ignoring group ", newValue, " because it cannot ",
-							"be converted to scope"));
+				if (groupIds.containsKey(groupId)) {
+					groupId = groupIds.get(groupId);
 				}
 
-				continue;
+				Group group = _groupLocalService.fetchGroup(groupId);
+
+				if (group == null) {
+					if (_log.isInfoEnabled()) {
+						_log.info(
+							StringBundler.concat(
+								"Ignoring group ", newValue, " because it ",
+								"cannot be converted to scope"));
+					}
+
+					continue;
+				}
+
+				newValue = assetPublisherHelper.getScopeId(
+					group, portletDataContext.getScopeGroupId());
 			}
 
 			try {

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/util/AssetPublisherWebUtil.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/util/AssetPublisherWebUtil.java
@@ -22,8 +22,8 @@ import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.asset.kernel.service.AssetTagLocalService;
 import com.liferay.asset.kernel.service.persistence.AssetEntryQuery;
 import com.liferay.asset.publisher.constants.AssetPublisherPortletKeys;
+import com.liferay.asset.publisher.util.AssetPublisherHelper;
 import com.liferay.asset.publisher.web.configuration.AssetPublisherPortletInstanceConfiguration;
-import com.liferay.asset.publisher.web.util.AssetPublisherUtil;
 import com.liferay.asset.util.AssetEntryQueryProcessor;
 import com.liferay.dynamic.data.mapping.util.DDMIndexer;
 import com.liferay.petra.string.StringPool;
@@ -441,11 +441,11 @@ public class AssetPublisherWebUtil {
 			long companyGroupId, Layout layout, boolean checkPermission)
 		throws PortalException {
 
-		long groupId = _assetPublisherUtil.getGroupIdFromScopeId(
+		long groupId = _assetPublisherHelper.getGroupIdFromScopeId(
 			scopeId, layout.getGroupId(), layout.isPrivateLayout());
 
 		if (scopeId.startsWith(
-				AssetPublisherUtil.SCOPE_ID_CHILD_GROUP_PREFIX)) {
+				AssetPublisherHelper.SCOPE_ID_CHILD_GROUP_PREFIX)) {
 
 			Group group = _groupLocalService.getGroup(groupId);
 
@@ -454,7 +454,7 @@ public class AssetPublisherWebUtil {
 			}
 		}
 		else if (scopeId.startsWith(
-					 AssetPublisherUtil.SCOPE_ID_PARENT_GROUP_PREFIX)) {
+					 AssetPublisherHelper.SCOPE_ID_PARENT_GROUP_PREFIX)) {
 
 			Group siteGroup = layout.getGroup();
 
@@ -643,11 +643,12 @@ public class AssetPublisherWebUtil {
 
 	private final List<AssetEntryQueryProcessor> _assetEntryQueryProcessors =
 		new CopyOnWriteArrayList<>();
-	private AssetPublisherPortletInstanceConfiguration
-		_assetPublisherPortletInstanceConfiguration;
 
 	@Reference
-	private AssetPublisherUtil _assetPublisherUtil;
+	private AssetPublisherHelper _assetPublisherHelper;
+
+	private AssetPublisherPortletInstanceConfiguration
+		_assetPublisherPortletInstanceConfiguration;
 
 	@Reference
 	private AssetTagLocalService _assetTagLocalService;

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/PortletDataContextImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/PortletDataContextImpl.java
@@ -2381,6 +2381,7 @@ public class PortletDataContextImpl implements PortletDataContext {
 
 				referenceElement.addAttribute(
 					"live-group-id", String.valueOf(liveGroupId));
+				referenceElement.addAttribute("group-key", group.getGroupKey());
 
 				if (group.isLayout()) {
 					try {

--- a/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/exportimport/staged/model/repository/StagedGroupStagedModelRepository.java
+++ b/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/exportimport/staged/model/repository/StagedGroupStagedModelRepository.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.service.LayoutSetLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.xml.Element;
 import com.liferay.site.model.adapter.StagedGroup;
 
@@ -121,11 +122,23 @@ public class StagedGroupStagedModelRepository
 			return null;
 		}
 
-		return fetchExistingGroup(portletDataContext, groupId, liveGroupId);
+		String groupKey = GetterUtil.getString(
+			referenceElement.attributeValue("group-key"));
+
+		return fetchExistingGroup(
+			portletDataContext, groupId, liveGroupId, groupKey);
 	}
 
 	public Group fetchExistingGroup(
 		PortletDataContext portletDataContext, long groupId, long liveGroupId) {
+
+		return fetchExistingGroup(
+			portletDataContext, groupId, liveGroupId, null);
+	}
+
+	public Group fetchExistingGroup(
+		PortletDataContext portletDataContext, long groupId, long liveGroupId,
+		String groupKey) {
 
 		Group liveGroup = _groupLocalService.fetchGroup(liveGroupId);
 
@@ -140,6 +153,14 @@ public class StagedGroupStagedModelRepository
 		}
 		else if (groupId == portletDataContext.getSourceGroupId()) {
 			existingGroupId = portletDataContext.getGroupId();
+		}
+		else if (Validator.isNotNull(groupKey)) {
+			Group groupKeyGroup = _groupLocalService.fetchGroup(
+				portletDataContext.getCompanyId(), groupKey);
+
+			if (groupKeyGroup != null) {
+				existingGroupId = groupKeyGroup.getGroupId();
+			}
 		}
 
 		// During remote staging, valid mappings are found when the reference's


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-84201

In order to maintain site scope configuration in Asset Publisher, now, for Remote Staging we stored a mapping information of groupIds (see  [LPS-60568](https://issues.liferay.com/browse/LPS-60568))

But in case of doing a export/import using LAR files, scope info is lost unless a site with same groupId exists.

In SME request [LPP-30970](https://issues.liferay.com/browse/LPP-30970) I agreed with @moltam89 to use groupKey as a fallback of groupId, so in case of not existing the exported groupId, we will search a group with the same name.