### PR TITLE
LPS-84228 Remove locale from URL in virtual host reference validation

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/content/processor/LayoutReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/content/processor/LayoutReferencesExportImportContentProcessor.java
@@ -797,7 +797,8 @@ public class LayoutReferencesExportImportContentProcessor
 					urlWithoutLocale.startsWith(
 						_PRIVATE_USER_SERVLET_MAPPING) ||
 					urlWithoutLocale.startsWith(
-						_PUBLIC_GROUP_SERVLET_MAPPING)) {
+						_PUBLIC_GROUP_SERVLET_MAPPING) ||
+					_isVirtualHostDefined(urlSB)) {
 
 					url = urlWithoutLocale;
 				}
@@ -913,6 +914,21 @@ public class LayoutReferencesExportImportContentProcessor
 
 				throw eicve;
 			}
+		}
+	}
+
+	private boolean _isVirtualHostDefined(StringBundler urlSB) {
+		String urlSBString = urlSB.toString();
+
+		if (urlSBString.contains(_DATA_HANDLER_PUBLIC_LAYOUT_SET_SECURE_URL) ||
+			urlSBString.contains(_DATA_HANDLER_PUBLIC_LAYOUT_SET_URL) ||
+			urlSBString.contains(_DATA_HANDLER_PRIVATE_LAYOUT_SET_SECURE_URL) ||
+			urlSBString.contains(_DATA_HANDLER_PRIVATE_LAYOUT_SET_URL)) {
+
+			return true;
+		}
+		else {
+			return false;
 		}
 	}
 


### PR DESCRIPTION
Hi @matethurzo ,

I discussed with @akosthurzo about this change. Originally, I wanted to remove the condition for `url = urlWithoutLocale;` altogether, but this scenario can only happen when there's a virtual host defined for the group.
So this change makes it possible to validate URLs, like "www.example.com/en/layoutname". These URLs were also considered valid even before the change: "www.example.com/layoutname" and "www.example.com/en/web/groupname/layoutname".

I saw that `urlSB` is already used in the code to detect whether virtual host was public/private, so I used it in the `_isVirtualHostDefined(...)` function as well

Please review my changes.

Thanks,
Vendel