### PR TITLE
LPS-85120 Default structure permissions are lost on LAR import if permissions were not exported

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/PortletDataContextImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/PortletDataContextImpl.java
@@ -2271,8 +2271,13 @@ public class PortletDataContextImpl implements PortletDataContext {
 
 		// Permissions
 
+		String xml = getZipEntryAsString(
+			ExportImportPathUtil.getSourceRootPath(this) +
+				"/portlet-data-permissions.xml");
+
 		if (!MapUtil.getBoolean(
-				_parameterMap, PortletDataHandlerKeys.PERMISSIONS)) {
+				_parameterMap, PortletDataHandlerKeys.PERMISSIONS) ||
+			Validator.isNull(xml)) {
 
 			serviceContext.setAddGroupPermissions(true);
 			serviceContext.setAddGuestPermissions(true);


### PR DESCRIPTION
From Alec:

> 
> Relevant tickets:
> 
> https://issues.liferay.com/browse/LPP-31376
> https://issues.liferay.com/browse/LPS-85120
> 
> hen importing a web content structure with "Import Permissions" enabled, but the LAR does not have permissions exported to it, then default structure permissions are lost.
> 
> Because the option to import permissions is enabled, it is assumed that guest and group permissions should not be added. However, my assumption is that the correct behavior is for, when the LAR does not contain any portlet information for permissions, to treat it the same as if permission imports are disabled, because I think it is a reasonable expectation that enabling it in this case should simply have no effect.
> 
> If you think there is a problem with this or something I have overlooked, please let me know. Thank you!