### PR TITLE
LPS-88118 NoSuchGroupException thrown when enabling staging with a Web Content article referenced from a deleted site

### DIFF
--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/exportimport/portlet/preferences/processor/JournalContentExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/exportimport/portlet/preferences/processor/JournalContentExportImportPortletPreferencesProcessor.java
@@ -295,8 +295,16 @@ public class JournalContentExportImportPortletPreferencesProcessor
 
 		try {
 			if (Validator.isNotNull(articleId) && (groupId != 0)) {
-				Group importedArticleGroup = _groupLocalService.getGroup(
+				Group importedArticleGroup = _groupLocalService.fetchGroup(
 					groupId);
+
+				if (importedArticleGroup == null) {
+					if (_log.isDebugEnabled()) {
+						_log.debug("No group found with group ID " + groupId);
+					}
+
+					return portletPreferences;
+				}
 
 				if (!ExportImportThreadLocal.isStagingInProcess() ||
 					importedArticleGroup.isStagedPortlet(


### PR DESCRIPTION
from @jonathanmccann 

> This issue is very similar to https://issues.liferay.com/browse/LPS-88014. The issue is that in Master after https://issues.liferay.com/browse/LPS-77336, the exception is no longer displayed in the logs even though the NoSuchGroupException is still being triggered.

>I decided to fix this in Master to avoid the unnecessary exception throwing but if you think it is better suited for a 7.0.x only fix then we can go that route as well.