### PR TITLE
[TECHNICAL SUPPORT] LPS-88254 Log trace should be WARN level

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/exportimport/portlet/preferences/processor/AssetPublisherExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/exportimport/portlet/preferences/processor/AssetPublisherExportImportPortletPreferencesProcessor.java
@@ -155,8 +155,8 @@ public class AssetPublisherExportImportPortletPreferencesProcessor
 				portletPreferences);
 		}
 		catch (Exception e) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(
+			if (_log.isWarnEnabled()) {
+				_log.warn(
 					"Unable to update portlet preferences while exporting " +
 						portletDataContext.getPortletId(),
 					e);
@@ -181,8 +181,8 @@ public class AssetPublisherExportImportPortletPreferencesProcessor
 				portletDataContext, portletPreferences);
 		}
 		catch (Exception e) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(
+			if (_log.isWarnEnabled()) {
+				_log.warn(
 					"Unable to update portlet preferences while importing " +
 						portletDataContext.getPortletId(),
 					e);

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/module-log4j.xml
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/module-log4j.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+	<category name="com.liferay.asset.publisher.web">
+		<priority value="WARN" />
+	</category>
+</log4j:configuration>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-88254

We are having several issues during asset publisher export/import (related to [LPS-82958](https://issues.liferay.com/browse/LPS-82958)) and I think we should change AssetPublisherExportImportPortletPreferencesProcessor trace from debug to warn in order to ease customer diagnosis in future issues.

/cc: @moltam89