### PR TITLE
[TECHNICAL SUPPORT] LPS-88571

### DIFF
--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/DLFileEntryTypeStagedModelDataHandler.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/DLFileEntryTypeStagedModelDataHandler.java
@@ -401,7 +401,7 @@ public class DLFileEntryTypeStagedModelDataHandler
 		while (group != null) {
 			DLFileEntryType existingDLFileEntryType =
 				fetchExistingFileEntryType(
-					uuid, groupId, fileEntryTypeKey, preloaded);
+					uuid, group.getGroupId(), fileEntryTypeKey, preloaded);
 
 			if (existingDLFileEntryType != null) {
 				return existingDLFileEntryType;

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/DLFileEntryTypeStagedModelDataHandler.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/DLFileEntryTypeStagedModelDataHandler.java
@@ -391,6 +391,10 @@ public class DLFileEntryTypeStagedModelDataHandler
 
 		Group group = _groupLocalService.fetchGroup(groupId);
 
+		if (group == null) {
+			return null;
+		}
+
 		long companyId = group.getCompanyId();
 
 		while (group != null) {

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/DLFileEntryTypeStagedModelDataHandler.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/DLFileEntryTypeStagedModelDataHandler.java
@@ -392,7 +392,8 @@ public class DLFileEntryTypeStagedModelDataHandler
 		Group group = _groupLocalService.fetchGroup(groupId);
 
 		if (group == null) {
-			return null;
+			return fetchExistingFileEntryType(
+				uuid, groupId, fileEntryTypeKey, preloaded);
 		}
 
 		long companyId = group.getCompanyId();

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/exportimport/data/handler/DDMStructureStagedModelDataHandler.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/exportimport/data/handler/DDMStructureStagedModelDataHandler.java
@@ -516,6 +516,10 @@ public class DDMStructureStagedModelDataHandler
 
 		Group group = _groupLocalService.fetchGroup(groupId);
 
+		if (group == null) {
+			return null;
+		}
+
 		long companyId = group.getCompanyId();
 
 		while (group != null) {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/exportimport/data/handler/DDMTemplateStagedModelDataHandler.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/exportimport/data/handler/DDMTemplateStagedModelDataHandler.java
@@ -512,6 +512,10 @@ public class DDMTemplateStagedModelDataHandler
 
 		Group group = _groupLocalService.fetchGroup(groupId);
 
+		if (group == null) {
+			return null;
+		}
+
 		long companyId = group.getCompanyId();
 
 		while (group != null) {

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
@@ -1085,6 +1085,10 @@ public class JournalArticleStagedModelDataHandler
 
 		Group group = _groupLocalService.fetchGroup(groupId);
 
+		if (group == null) {
+			return null;
+		}
+
 		long companyId = group.getCompanyId();
 
 		while (group != null) {

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
@@ -1093,7 +1093,7 @@ public class JournalArticleStagedModelDataHandler
 
 		while (group != null) {
 			JournalArticle article = fetchExistingArticle(
-				articleUuid, articleResourceUuid, groupId, articleId,
+				articleUuid, articleResourceUuid, group.getGroupId(), articleId,
 				newArticleId, version, preloaded);
 
 			if (article != null) {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-88571

Regression caused by [LPS-54392](https://issues.liferay.com/browse/LPS-54392), in case groupId doesn't exists a NPE is thrown.

**Important:** There is a special case only for DLFileEntryType object with key=BASIC-DOCUMENT with groupId=0 because is precreate during Liferay startup with _fileEntryTypeId=0, companyId=0 and groupId=0_
So only in DLFileEntryTypeStagedModelDataHandler is necessary to handle that special case.