### PR TITLE
LPS-88378 Add imported layout to Layouts map in PortletDataContext, b…efore starting to import its dependencies. Restore plids in PortletDataContext after importing parent Layout.

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
@@ -572,6 +572,14 @@ public class LayoutStagedModelDataHandler
 			importedLayout = existingLayout;
 		}
 
+		Map<Long, Long> layoutPlids =
+			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
+				Layout.class);
+
+		layoutPlids.put(layout.getPlid(), importedLayout.getPlid());
+
+		layouts.put(oldLayoutId, importedLayout);
+
 		portletDataContext.setPlid(importedLayout.getPlid());
 		portletDataContext.setOldPlid(layout.getPlid());
 
@@ -587,8 +595,17 @@ public class LayoutStagedModelDataHandler
 		if ((parentLayoutId != LayoutConstants.DEFAULT_PARENT_LAYOUT_ID) &&
 			(parentLayoutElement != null)) {
 
-			StagedModelDataHandlerUtil.importStagedModel(
-				portletDataContext, parentLayoutElement);
+			long originalOldPlid = portletDataContext.getOldPlid();
+			long originalPlid = portletDataContext.getPlid();
+
+			try {
+				StagedModelDataHandlerUtil.importStagedModel(
+					portletDataContext, parentLayoutElement);
+			}
+			finally {
+				portletDataContext.setOldPlid(originalOldPlid);
+				portletDataContext.setPlid(originalPlid);
+			}
 
 			Layout importedParentLayout = layouts.get(parentLayoutId);
 
@@ -707,14 +724,6 @@ public class LayoutStagedModelDataHandler
 		_layoutLocalService.updateLayout(importedLayout);
 
 		_layoutSetLocalService.updatePageCount(groupId, privateLayout);
-
-		Map<Long, Long> layoutPlids =
-			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
-				Layout.class);
-
-		layoutPlids.put(layout.getPlid(), importedLayout.getPlid());
-
-		layouts.put(oldLayoutId, importedLayout);
 
 		if ((Objects.equals(layout.getType(), LayoutConstants.TYPE_PORTLET) &&
 			 Validator.isNotNull(layout.getTypeSettings())) ||


### PR DESCRIPTION
Notes from Vendel:

> As discussed, I changed the order of importing dependencies of a Layout and adding the Layout (that is being currently imported) into the layouts map of PortletDataContext. So subsequent imports of its dependencies will be able to find it.
> Also, since importing the Layout's dependencies changes the plid and oldPlid variables of the PortletDataContext, we should restore them to make sure we are importing the right Layout.
> 
> Please review my changes.
> 
> Thanks,
> Vendel