### PR TITLE
[TECHNICAL-SUPPORT] LPS-89546 Page Versioning with Page Template Propagation

### DIFF
--- a/portal-impl/src/com/liferay/portlet/sites/util/SitesImpl.java
+++ b/portal-impl/src/com/liferay/portlet/sites/util/SitesImpl.java
@@ -335,7 +335,9 @@ public class SitesImpl implements Sites {
 		typeSettingsProperties.setProperty(
 			LAST_MERGE_TIME, String.valueOf(modifiedDate.getTime()));
 
-		LayoutLocalServiceUtil.updateLayout(targetLayout);
+		LayoutLocalServiceUtil.updateLayout(
+			targetLayout.getGroupId(), targetLayout.isPrivateLayout(),
+			targetLayout.getLayoutId(), targetLayout.getTypeSettings());
 
 		UnicodeProperties prototypeTypeSettingsProperties =
 			layoutPrototypeLayout.getTypeSettingsProperties();
@@ -1627,6 +1629,23 @@ public class SitesImpl implements Sites {
 
 		long lastMergeTime = GetterUtil.getLong(
 			layout.getTypeSettingsProperty(LAST_MERGE_TIME));
+
+		if (lastMergeTime == 0) {
+			try {
+				MergeLayoutPrototypesThreadLocal.setInProgress(true);
+
+				Layout targetLayout = LayoutLocalServiceUtil.getLayout(
+					layout.getPlid());
+
+				if (targetLayout != null) {
+					lastMergeTime = GetterUtil.getLong(
+						targetLayout.getTypeSettingsProperty(LAST_MERGE_TIME));
+				}
+			}
+			finally {
+				MergeLayoutPrototypesThreadLocal.setInProgress(false);
+			}
+		}
 
 		LayoutPrototype layoutPrototype =
 			LayoutPrototypeLocalServiceUtil.

--- a/portal-kernel/src/com/liferay/portal/kernel/model/LayoutStagingHandler.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/LayoutStagingHandler.java
@@ -301,16 +301,16 @@ public class LayoutStagingHandler implements InvocationHandler, Serializable {
 		Arrays.asList(
 			"getColorScheme", "getColorSchemeId", "getCss", "getCssText",
 			"getDescription", "getGroupId", "getHTMLTitle", "getIconImage",
-			"getIconImageId", "getKeywords", "getLayoutSet", "getName",
-			"getRobots", "getTheme", "getThemeId", "getThemeSetting",
+			"getIconImageId", "getKeywords", "getLayoutSet", "getModifiedDate",
+			"getName", "getRobots", "getTheme", "getThemeId", "getThemeSetting",
 			"getTitle", "getTypeSettings", "getTypeSettingsProperties",
 			"getTypeSettingsProperty", "isContentDisplayPage", "isEscapedModel",
 			"isIconImage", "isInheritLookAndFeel", "setColorSchemeId", "setCss",
 			"setDescription", "setDescriptionMap", "setEscapedModel",
 			"setGroupId", "setIconImage", "setIconImageId", "setKeywords",
-			"setKeywordsMap", "setName", "setNameMap", "setRobots",
-			"setRobotsMap", "setThemeId", "setTitle", "setTitleMap",
-			"setTypeSettings", "setTypeSettingsProperties"));
+			"setKeywordsMap", "setModifiedDate", "setName", "setNameMap",
+			"setRobots", "setRobotsMap", "setThemeId", "setTitle",
+			"setTitleMap", "setTypeSettings", "setTypeSettingsProperties"));
 
 	private final Layout _layout;
 	private LayoutRevision _layoutRevision;


### PR DESCRIPTION
Hi @matethurzo ,

As discussed in [PTR-462](https://issues.liferay.com/browse/PTR-462), the Page Versioning and Page Template Propagation features can work together, but only with some limitations.
One of the main problems is that page template propagation is always executed, for every single `getLayout()` call, ignoring the `last-merge-time` property. The purpose of this change is to fix this problem. It is caused mostly by the fact that template propagation methods can either receive a normal `Layout` object or a wrapped proxy version of it, containing a `Layout` and a `LayoutRevision`.
* I modified the call to `updateLayout()` method to update the `last-merge-time` property in `LayoutRevision`
* Also, when `lastMergeTime == 0` it makes a second attempt to query it from the `LayoutRevision`
* Since the `modifiedDate` of the proxy object is coming from the `Layout`, I added `getModifiedDate` and `setModifiedDate` methods to a list, so it refers to `LayoutRevision` instead.

Please review my changes.

Thanks,
Vendel