### PR TITLE
LPS-90112 Improve the performance of the SystemEventVerifyProcess

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/verify/system/event/SystemEventVerifyProcess.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/verify/system/event/SystemEventVerifyProcess.java
@@ -57,11 +57,14 @@ public class SystemEventVerifyProcess extends VerifyProcess {
 
 		actionableDynamicQuery.setPerformActionMethod(
 			(Group group) -> {
-				if (!_systemEventLocalService.validateGroup(
-						group.getGroupId())) {
+				long liveGroupId = group.getLiveGroupId();
 
-					_systemEventLocalService.deleteSystemEvents(
-						group.getGroupId());
+				if (liveGroupId == 0) {
+					liveGroupId = group.getGroupId();
+				}
+
+				if (!_systemEventLocalService.validateGroup(liveGroupId)) {
+					_systemEventLocalService.deleteSystemEvents(liveGroupId);
 				}
 			});
 

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/verify/system/event/SystemEventVerifyProcess.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/verify/system/event/SystemEventVerifyProcess.java
@@ -15,6 +15,9 @@
 package com.liferay.exportimport.internal.verify.system.event;
 
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
+import com.liferay.portal.kernel.dao.orm.Property;
+import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
+import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.service.GroupLocalService;
@@ -37,6 +40,20 @@ public class SystemEventVerifyProcess extends VerifyProcess {
 	protected void deleteInvalidSystemEvents() throws PortalException {
 		ActionableDynamicQuery actionableDynamicQuery =
 			_groupLocalService.getActionableDynamicQuery();
+
+		actionableDynamicQuery.setAddCriteriaMethod(
+			dynamicQuery -> {
+				Property liveGroupIdProperty = PropertyFactoryUtil.forName(
+					"liveGroupId");
+
+				Property remoteStagingGroupCountProperty =
+					PropertyFactoryUtil.forName("remoteStagingGroupCount");
+
+				dynamicQuery.add(
+					RestrictionsFactoryUtil.or(
+						liveGroupIdProperty.ne(0L),
+						remoteStagingGroupCountProperty.gt(0)));
+			});
 
 		actionableDynamicQuery.setPerformActionMethod(
 			(Group group) -> {


### PR DESCRIPTION
Hi @matethurzo,

We have detected performance issues with the process SystemEventVerifyProcess during the upgrade. For example with 400000 groups with no staging this process takes 15 hours in DB2. We have modified the logic to only process live groups, the execution took 1 second after this change.

Could you review if everything is ok regarding my changes?

Thanks.

cc/ @jorgediaz-lr