### PR TITLE
LPS-88408 Scheduled publish failure don't have an entry under Staging

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/StagingImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/StagingImpl.java
@@ -456,7 +456,6 @@ public class StagingImpl implements Staging {
 			settingsMap, "remotePathContext");
 		boolean secureConnection = MapUtil.getBoolean(
 			settingsMap, "secureConnection");
-
 		boolean remotePrivateLayout = MapUtil.getBoolean(
 			settingsMap, "remotePrivateLayout");
 
@@ -1665,8 +1664,9 @@ public class StagingImpl implements Staging {
 		else if (e.getCause() instanceof ConnectException) {
 			Map settingsMap = exportImportConfiguration.getSettingsMap();
 
-			String remoteAddress = (String)settingsMap.get("remoteAddress");
-			String remotePort = String.valueOf(settingsMap.get("remotePort"));
+			String remoteAddress = MapUtil.getString(
+				settingsMap, "remoteAddress");
+			String remotePort = MapUtil.getString(settingsMap, "remotePort");
 
 			String argument = remoteAddress + ":" + remotePort;
 

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/StagingImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/StagingImpl.java
@@ -457,10 +457,6 @@ public class StagingImpl implements Staging {
 		boolean secureConnection = MapUtil.getBoolean(
 			settingsMap, "secureConnection");
 
-		_groupLocalService.validateRemote(
-			exportImportConfiguration.getGroupId(), remoteAddress, remotePort,
-			remotePathContext, secureConnection, targetGroupId);
-
 		boolean remotePrivateLayout = MapUtil.getBoolean(
 			settingsMap, "remotePrivateLayout");
 
@@ -524,10 +520,6 @@ public class StagingImpl implements Staging {
 			int remotePort, String remotePathContext, boolean secureConnection,
 			long remoteGroupId, boolean remotePrivateLayout)
 		throws PortalException {
-
-		_groupLocalService.validateRemote(
-			sourceGroupId, remoteAddress, remotePort, remotePathContext,
-			secureConnection, remoteGroupId);
 
 		PermissionChecker permissionChecker =
 			PermissionThreadLocal.getPermissionChecker();

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/StagingImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/StagingImpl.java
@@ -162,6 +162,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.Serializable;
 
+import java.net.ConnectException;
 import java.net.MalformedURLException;
 import java.net.URL;
 
@@ -449,7 +450,6 @@ public class StagingImpl implements Staging {
 		Map<String, Serializable> settingsMap =
 			exportImportConfiguration.getSettingsMap();
 
-		long targetGroupId = MapUtil.getLong(settingsMap, "targetGroupId");
 		String remoteAddress = MapUtil.getString(settingsMap, "remoteAddress");
 		int remotePort = MapUtil.getInteger(settingsMap, "remotePort");
 		String remotePathContext = MapUtil.getString(
@@ -1661,6 +1661,27 @@ public class StagingImpl implements Staging {
 				String.valueOf(
 					UploadServletRequestConfigurationHelperUtil.getMaxSize()));
 			errorType = ServletResponseConstants.SC_FILE_SIZE_EXCEPTION;
+		}
+		else if (e.getCause() instanceof ConnectException) {
+			Map settingsMap = exportImportConfiguration.getSettingsMap();
+
+			String remoteAddress = (String)settingsMap.get("remoteAddress");
+			String remotePort = String.valueOf(settingsMap.get("remotePort"));
+
+			StringBuilder sb = new StringBuilder();
+
+			sb.append(remoteAddress);
+			sb.append(":");
+			sb.append(remotePort);
+
+			errorMessage = LanguageUtil.format(
+				resourceBundle,
+				"could-not-connect-to-address-x.-please-verify-that-the-" +
+					"specified-port-is-correct-and-that-the-remote-server-is-" +
+						"configured-to-accept-requests-from-this-server",
+				sb.toString());
+
+			errorType = ServletResponseConstants.SC_FILE_CUSTOM_EXCEPTION;
 		}
 		else {
 			errorMessage = e.getLocalizedMessage();

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/StagingImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/StagingImpl.java
@@ -1668,18 +1668,14 @@ public class StagingImpl implements Staging {
 			String remoteAddress = (String)settingsMap.get("remoteAddress");
 			String remotePort = String.valueOf(settingsMap.get("remotePort"));
 
-			StringBuilder sb = new StringBuilder();
-
-			sb.append(remoteAddress);
-			sb.append(":");
-			sb.append(remotePort);
+			String argument = remoteAddress + ":" + remotePort;
 
 			errorMessage = LanguageUtil.format(
 				resourceBundle,
 				"could-not-connect-to-address-x.-please-verify-that-the-" +
 					"specified-port-is-correct-and-that-the-remote-server-is-" +
 						"configured-to-accept-requests-from-this-server",
-				sb.toString());
+				argument);
 
 			errorType = ServletResponseConstants.SC_FILE_CUSTOM_EXCEPTION;
 		}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-88408

From @ajsampang67:

> **Explanation:**
> 83cedf9308e234cd39fcfcf3d15c2c5df0978897
> When setting up remote staging, [StagingLocalServiceImpl.java calls the validateRemote() method](https://github.com/liferay/liferay-portal/blob/fd98fdbf6469dc24030b24659228f69dabc3aea9/portal-impl/src/com/liferay/portlet/exportimport/service/impl/StagingLocalServiceImpl.java#L380-L382). Calling this every time we want to publish/copy layouts is repetitive, as we already validated after configuration. This same validation call was also preventing the correct exception handling for BackgroundTask, which ultimately would lead to our Staging Process List UI entry.
> 
> 4f9a653b73a82a8c4e1c70cac6d25c7210de757d
> We were previously catching the ConnectException in the final "else" of [get getExceptionMessagesJSONObject()](https://github.com/liferay/liferay-portal/blob/a50180db50f53f86c6a96fadb396d5a7fce4a645/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/StagingImpl.java#L741) resulting in a generic message. Added a catch for "ConnectException" to provide a more specific error message. Had to use ".getCause()" as the exception is wrapped in a SystemException. The alternate change of throwing a ConnectionException instead would require a method signature change. Copied [the message used](https://github.com/liferay/liferay-portal/blob/7584298c03306dbc50e34a1b9e64b6d10b3c5db3/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/process_error/error/error_remote_export_exception.jspf#L24) when failing a configuration due to live server down when first initializing staging. 