### PR TITLE
LPS-90347 SF Web Content Display Configuration Templates can replace JournalContentSearch entries

### DIFF
--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/exportimport/portlet/preferences/processor/JournalContentExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/exportimport/portlet/preferences/processor/JournalContentExportImportPortletPreferencesProcessor.java
@@ -48,8 +48,10 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portlet.PortletPreferencesImpl;
 
 import java.util.List;
 import java.util.Map;
@@ -348,7 +350,17 @@ public class JournalContentExportImportPortletPreferencesProcessor
 						}
 					}
 
-					if (portletDataContext.getPlid() > 0) {
+					int prefOwnerType = -1;
+
+					if (portletPreferences instanceof PortletPreferencesImpl) {
+						prefOwnerType =
+							((PortletPreferencesImpl)portletPreferences).
+								getOwnerType();
+					}
+
+					if ((portletDataContext.getPlid() > 0) && (prefOwnerType !=
+							PortletKeys.PREFS_OWNER_TYPE_ARCHIVED)) {
+
 						Layout layout = _layoutLocalService.fetchLayout(
 							portletDataContext.getPlid());
 

--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/exportimport/portlet/preferences/processor/JournalContentExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/exportimport/portlet/preferences/processor/JournalContentExportImportPortletPreferencesProcessor.java
@@ -358,7 +358,8 @@ public class JournalContentExportImportPortletPreferencesProcessor
 								getOwnerType();
 					}
 
-					if ((portletDataContext.getPlid() > 0) && (prefOwnerType !=
+					if ((portletDataContext.getPlid() > 0) &&
+						(prefOwnerType !=
 							PortletKeys.PREFS_OWNER_TYPE_ARCHIVED)) {
 
 						Layout layout = _layoutLocalService.fetchLayout(


### PR DESCRIPTION
Hi Máté,

This fix prevents updating the journalContentSearch table in case of ARCHIVED preferences, as they don't belong to pages.

Regards,
Tamás