### PR TITLE
LPS-90924 When a "page revision" reviewer modifies a page, it shouldn't go to the workflow again

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/PortletPreferencesLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletPreferencesLocalServiceImpl.java
@@ -750,6 +750,11 @@ public class PortletPreferencesLocalServiceImpl
 		}
 
 		try {
+			boolean hasWorkflowTask = StagingUtil.hasWorkflowTask(
+				serviceContext.getUserId(), layoutRevision);
+
+			serviceContext.setAttribute("revisionInProgress", hasWorkflowTask);
+
 			layoutRevision = layoutRevisionLocalService.updateLayoutRevision(
 				serviceContext.getUserId(),
 				layoutRevision.getLayoutRevisionId(),


### PR DESCRIPTION
Hey Máté,

This fix ensures that the reviewed layoutrevison is updated instead of creating a new one, when a reviewer modifies a portlet configuration.

Since LPS-25271 this was working while moving a portlets, now Vendel extended it to work for saving portlet configurations as well.

Best,
Tamás