### PR TITLE
LPS-91735 | Cannot export/import ddm structure in Global site between instances

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/exportimport/data/handler/DDMStructureStagedModelDataHandler.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/exportimport/data/handler/DDMStructureStagedModelDataHandler.java
@@ -347,8 +347,11 @@ public class DDMStructureStagedModelDataHandler
 				(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
 					Group.class);
 
-			if (groupId != groupIds.get(
-					portletDataContext.getCompanyGroupId())) {
+			Long companyGroupIdValue = groupIds.get(
+				portletDataContext.getCompanyGroupId());
+
+			if ((companyGroupIdValue == null) ||
+				(groupId != companyGroupIdValue)) {
 
 				groupId = portletDataContext.getCompanyGroupId();
 			}


### PR DESCRIPTION
Hi @matethurzo, 

A NPE can occur if checking by a key in a map of Long's get's a null and then it's compared with a primitive long. The fix takes care of this case. Please let me know if you have any questions. 

Please note the long is-caused-by chain of tickets for this issue.

Let me know if you have any questions.