### PR TITLE
[TECHNICAL-SUPPORT] LPS-94738 Import into staged site

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/controller/PortletImportControllerImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/controller/PortletImportControllerImpl.java
@@ -830,6 +830,12 @@ public class PortletImportControllerImpl implements PortletImportController {
 		portletDataContext.setScopeGroupId(groupId);
 		portletDataContext.setScopeLayoutUuid(StringPool.BLANK);
 		portletDataContext.setScopeType(StringPool.BLANK);
+
+		Map<Long, Long> groupIds =
+			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
+				Group.class);
+
+		groupIds.put(portletDataContext.getSourceGroupId(), groupId);
 	}
 
 	@Override

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
@@ -971,6 +971,14 @@ public class JournalArticleStagedModelDataHandler
 				articlePrimaryKeys.put(
 					article.getPrimaryKey(), importedArticle.getPrimaryKey());
 
+				Map<String, Long> articleGroupIds =
+					(Map<String, Long>)portletDataContext.getNewPrimaryKeysMap(
+						JournalArticle.class + ".groupId");
+
+				articleGroupIds.put(
+					String.valueOf(article.getArticleId()),
+					importedArticle.getGroupId());
+
 				_importAssetDisplayPage(
 					portletDataContext, article, importedArticle);
 			}


### PR DESCRIPTION
Hi @matethurzo,

It seems like many import processes use the `portletDataContext.getNewPrimaryKeysMap(Group.class)` key map to get the scopeGroupId. That's the case with JournalDisplayPortlet prefereces as well. However, when staging is active and we are importing to a staging site, the code in [ExportImportHelperImpl.setPortletScope(..)]( https://github.com/liferay/liferay-portal/blob/master/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/ExportImportHelperImpl.java#L1281) overwrites this value only to the Live group's `groupId` when a protlet is not staged (there are always some non-staged portlets). The problem is, that it remains the the `portletDataContext` even when e.g.: JournalDisplayPortlet import tries to find a referenced article. It will use the Live `groupId` instead of the staging one.
This is the loop that goes through all the portlet elements: [LayoutStagedModelDataHandler.importLayoutPortlets(..)](https://github.com/liferay/liferay-portal/blob/master/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java#L1416). And whichever portlet comes first, has the chance to set the `groupId` to Live, and all the other portlets will read this.

My first commit https://github.com/matethurzo/liferay-portal/commit/0efa12810c8c9d7ca6742f818fcb1dfba7db5e35 will reset this `groupId` in the Group keys map as well.

The second commit https://github.com/matethurzo/liferay-portal/commit/9e427612802420a1b1e7dfdd34fe65a209143572 will add a groupId for each article in the key map, making sure that the right groupId is read in [JournalContentExportImportPortletPreferencesProcessor](https://github.com/liferay/liferay-portal/blob/master/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/exportimport/portlet/preferences/processor/JournalContentExportImportPortletPreferencesProcessor.java#L301). This is required for the scenario when we want to import into a staging site and the web contents are not staged.

Please review my changes. Also, since this problem can be solved in many different ways, there might be another, more appropriate solution.

Thanks,
Vendel